### PR TITLE
fix css naming used by deliteful button stylesheets.

### DIFF
--- a/CssState.js
+++ b/CssState.js
@@ -38,7 +38,7 @@ define([
 					return;
 				}
 				var classes = baseClasses.map(function (c) {
-					return c + modifier[0].toUpperCase() + modifier.substr(1);
+					return c + "-" + modifier;
 				});
 				domClass.toggle(self, classes, condition);
 			}

--- a/themes/blackberry/variables.less
+++ b/themes/blackberry/variables.less
@@ -41,22 +41,22 @@
 }
 
 // background styles of form controls
-.dui-button-background-image () { .default-button-background-image(); }
-.dui-button-selected-background-image () { .default-button-selected-background-image(); }
-.dui-blue-button-background-image () { .default-blue-button-background-image(); }
-.dui-blue-button-selected-background-image () { .default-button-selected-background-image(); }
-.dui-red-button-background-image () { .background-image-linear-gradient-top-bottom-2-stops(#fa9d58, #ee4115, 0.5, #ff4d25, 0.5, #ed4d15); }
-.dui-red-button-selected-background-image () { .default-button-selected-background-image(); }
-.dui-button-checked-background-image () { .default-button-background-image(); }
+.d-button-background-image () { .default-button-background-image(); }
+.d-button-selected-background-image () { .default-button-selected-background-image(); }
+.d-button-blue-background-image () { .default-blue-button-background-image(); }
+.d-button-blue-selected-background-image () { .default-button-selected-background-image(); }
+.d-button-red-background-image () { .background-image-linear-gradient-top-bottom-2-stops(#fa9d58, #ee4115, 0.5, #ff4d25, 0.5, #ed4d15); }
+.d-button-red-selected-background-image () { .default-button-selected-background-image(); }
+.d-button-checked-background-image () { .default-button-background-image(); }
 
 // background styles of form controls (for gecko)
-@dui-button-background-image-gecko: @default-button-background-image-gecko;
-@dui-button-selected-background-image-gecko: @default-button-selected-background-image-gecko;
-@dui-blue-button-background-image-gecko: @default-blue-button-background-image-gecko;
-@dui-blue-button-selected-background-image-gecko: @default-button-selected-background-image-gecko;
-@dui-red-button-background-image-gecko: -moz-linear-gradient(top, #fa9d58 0%, #ff4d25 50%, #ed4d15 50%, #ee4115 100%);
-@dui-red-button-selected-background-image-gecko: @default-button-selected-background-image-gecko;
-@dui-button-checked-background-image-gecko: @default-button-background-image-gecko;
+@d-button-background-image-gecko: @default-button-background-image-gecko;
+@d-button-selected-background-image-gecko: @default-button-selected-background-image-gecko;
+@d-button-blue-background-image-gecko: @default-blue-button-background-image-gecko;
+@d-button-blue-selected-background-image-gecko: @default-button-selected-background-image-gecko;
+@d-button-red-background-image-gecko: -moz-linear-gradient(top, #fa9d58 0%, #ff4d25 50%, #ed4d15 50%, #ee4115 100%);
+@d-button-red-selected-background-image-gecko: @default-button-selected-background-image-gecko;
+@d-button-red-checked-background-image-gecko: @default-button-background-image-gecko;
 
 // common.less
 .mobile-body-styles () {

--- a/themes/bootstrap/variables.less
+++ b/themes/bootstrap/variables.less
@@ -107,22 +107,22 @@
 }
 
 // background styles of form controls
-.dui-button-background-image () { .background-image-linear-gradient-top-bottom(@lightColor, @lightColor04); }
-.dui-button-selected-background-image () { .default-selected-background-image(); }
-.dui-blue-button-background-image () { .default-blue-button-background-image(); }
-.dui-blue-button-selected-background-image () { .default-selected-background-image(); }
-.dui-red-button-background-image () { .background-image-linear-gradient-top-bottom(@redColor02, @redColor); }
-.dui-red-button-selected-background-image () { .default-selected-background-image(); }
-.dui-button-checked-background-image () { .dui-button-background-image(); }
+.d-button-background-image () { .background-image-linear-gradient-top-bottom(@lightColor, @lightColor04); }
+.d-button-selected-background-image () { .default-selected-background-image(); }
+.d-button-blue-background-image () { .default-blue-button-background-image(); }
+.d-button-blue-selected-background-image () { .default-selected-background-image(); }
+.d-button-red-background-image () { .background-image-linear-gradient-top-bottom(@redColor02, @redColor); }
+.d-button-red-selected-background-image () { .default-selected-background-image(); }
+.d-button-checked-background-image () { .d-button-background-image(); }
 
 // background styles of form controls (for gecko)
-@dui-button-background-image-gecko: -moz-linear-gradient(top, @lightColor 0%, @lightColor04 100%);
-@dui-button-selected-background-image-gecko: @default-selected-background-image-gecko;
-@dui-blue-button-background-image-gecko: @default-blue-button-background-image-gecko;
-@dui-blue-button-selected-background-image-gecko: @default-selected-background-image-gecko;
-@dui-red-button-background-image-gecko: -moz-linear-gradient(top, @redColor02 0%, @redColor 100%);
-@dui-red-button-selected-background-image-gecko: @default-selected-background-image-gecko;
-@dui-button-checked-background-image-gecko: @dui-button-background-image-gecko;
+@d-button-background-image-gecko: -moz-linear-gradient(top, @lightColor 0%, @lightColor04 100%);
+@d-button-selected-background-image-gecko: @default-selected-background-image-gecko;
+@d-button-blue-background-image-gecko: @default-blue-button-background-image-gecko;
+@d-button-blue-selected-background-image-gecko: @default-selected-background-image-gecko;
+@d-button-red-background-image-gecko: -moz-linear-gradient(top, @redColor02 0%, @redColor 100%);
+@d-button-red-selected-background-image-gecko: @default-selected-background-image-gecko;
+@d-button-checked-background-image-gecko: @d-button-background-image-gecko;
 
 // common.less
 .mobile-body-styles () {

--- a/themes/custom/variables.less
+++ b/themes/custom/variables.less
@@ -107,22 +107,22 @@
 }
 
 // background styles of form controls
-.dui-button-background-image () { .background-image-linear-gradient-top-bottom(@lightColor, @lightColor04); }
-.dui-button-selected-background-image () { .default-selected-background-image(); }
-.dui-blue-button-background-image () { .default-blue-button-background-image(); }
-.dui-blue-button-selected-background-image () { .default-selected-background-image(); }
-.dui-red-button-background-image () { .background-image-linear-gradient-top-bottom(@redColor02, @redColor); }
-.dui-red-button-selected-background-image () { .default-selected-background-image(); }
-.dui-button-checked-background-image () { .dui-button-background-image(); }
+.d-button-background-image () { .background-image-linear-gradient-top-bottom(@lightColor, @lightColor04); }
+.d-button-selected-background-image () { .default-selected-background-image(); }
+.d-button-blue-background-image () { .default-blue-button-background-image(); }
+.d-button-blue-selected-background-image () { .default-selected-background-image(); }
+.d-button-red-background-image () { .background-image-linear-gradient-top-bottom(@redColor02, @redColor); }
+.d-button-red-selected-background-image () { .default-selected-background-image(); }
+.d-button-checked-background-image () { .d-button-background-image(); }
 
 // background styles of form controls (for gecko)
-@dui-button-background-image-gecko: -moz-linear-gradient(top, @lightColor 0%, @lightColor04 100%);
-@dui-button-selected-background-image-gecko: @default-selected-background-image-gecko;
-@dui-blue-button-background-image-gecko: @default-blue-button-background-image-gecko;
-@dui-blue-button-selected-background-image-gecko: @default-selected-background-image-gecko;
-@dui-red-button-background-image-gecko: -moz-linear-gradient(top, @redColor02 0%, @redColor 100%);
-@dui-red-button-selected-background-image-gecko: @default-selected-background-image-gecko;
-@dui-button-checked-background-image-gecko: @dui-button-background-image-gecko;
+@d-button-background-image-gecko: -moz-linear-gradient(top, @lightColor 0%, @lightColor04 100%);
+@d-button-selected-background-image-gecko: @default-selected-background-image-gecko;
+@d-button-blue-background-image-gecko: @default-blue-button-background-image-gecko;
+@d-button-blue-selected-background-image-gecko: @default-selected-background-image-gecko;
+@d-button-red-background-image-gecko: -moz-linear-gradient(top, @redColor02 0%, @redColor 100%);
+@d-button-red-selected-background-image-gecko: @default-selected-background-image-gecko;
+@d-button-checked-background-image-gecko: @d-button-background-image-gecko;
 
 // common.less
 .mobile-body-styles () {

--- a/themes/holodark/variables.less
+++ b/themes/holodark/variables.less
@@ -75,24 +75,24 @@
 }
 
 // background styles of form controls
-.dui-button-background-image () { .default-button-border-styles; }
+.d-button-background-image () { .default-button-border-styles; }
 
-.dui-button-selected-background-image () { .default-button-selected-background-image(); }
-.dui-blue-button-background-image () { .default-blue-button-background-image(); }
-.dui-blue-button-selected-background-image () { .default-button-selected-background-image(); }
-.dui-red-button-background-image () { .background-image-linear-gradient-top-bottom-2-stops(#fa9d58, #ee4115, 0.5, #ff4d25, 0.5, #ed4d15);}
+.d-button-selected-background-image () { .default-button-selected-background-image(); }
+.d-button-blue-background-image () { .default-blue-button-background-image(); }
+.d-button-blue-selected-background-image () { .default-button-selected-background-image(); }
+.d-button-red-background-image () { .background-image-linear-gradient-top-bottom-2-stops(#fa9d58, #ee4115, 0.5, #ff4d25, 0.5, #ed4d15);}
 
-.dui-red-button-selected-background-image () { .default-button-selected-background-image(); }
-.dui-button-checked-background-image () { background-color: transparent; }
+.d-button-red-selected-background-image () { .default-button-selected-background-image(); }
+.d-button-checked-background-image () { background-color: transparent; }
 
 // background styles of form controls (for gecko)
-@dui-button-background-image-gecko: none;
-@dui-button-selected-background-image-gecko: @default-button-selected-background-image-gecko;
-@dui-blue-button-background-image-gecko: @default-blue-button-background-image-gecko;
-@dui-blue-button-selected-background-image-gecko: @default-button-selected-background-image-gecko;
-@dui-red-button-background-image-gecko: none;
-@dui-red-button-selected-background-image-gecko: none;
-@dui-button-checked-background-image-gecko: none;
+@d-button-background-image-gecko: none;
+@d-button-selected-background-image-gecko: @default-button-selected-background-image-gecko;
+@d-button-blue-background-image-gecko: @default-blue-button-background-image-gecko;
+@d-button-blue-selected-background-image-gecko: @default-button-selected-background-image-gecko;
+@d-button-red-background-image-gecko: none;
+@d-button-red-selected-background-image-gecko: none;
+@d-button-checked-background-image-gecko: none;
 
 // common.less
 .mobile-body-styles () {

--- a/themes/ios/variables.less
+++ b/themes/ios/variables.less
@@ -41,22 +41,22 @@
 }
 
 // background styles of form controls
-.dui-button-background-image () { .background-image-linear-gradient-top-bottom-2-stops(#fdfdfd, #cecece, 0.5, #f8f8f8, 0.5, #eeeeee); }
-.dui-button-selected-background-image () { .background-image-linear-gradient-top-bottom-2-stops(#f0f0f0, #bfbfbf, 0.5, #ebebeb, 0.5, #dedede); }
-.dui-blue-button-background-image () { .default-blue-button-background-image(); }
-.dui-blue-button-selected-background-image () { .background-image-linear-gradient-top-bottom-2-stops(#8ea4c1, #4a6c9b, 0.5, #5877a2, 0.5, #476999); }
-.dui-red-button-background-image () { .background-image-linear-gradient-top-bottom-2-stops(#fa9d58, #ee4115, 0.5, #ff4d25, 0.5, #ed4d15); }
-.dui-red-button-selected-background-image () { .background-image-linear-gradient-top-bottom-2-stops(#c1a48e, #9b6c4a, 0.5, #a27758, 0.5, #996947); }
-.dui-button-checked-background-image () { .default-blue-button-background-image(); }
+.d-button-background-image () { .background-image-linear-gradient-top-bottom-2-stops(#fdfdfd, #cecece, 0.5, #f8f8f8, 0.5, #eeeeee); }
+.d-button-selected-background-image () { .background-image-linear-gradient-top-bottom-2-stops(#f0f0f0, #bfbfbf, 0.5, #ebebeb, 0.5, #dedede); }
+.d-button-blue-background-image () { .default-blue-button-background-image(); }
+.d-button-blue-selected-background-image () { .background-image-linear-gradient-top-bottom-2-stops(#8ea4c1, #4a6c9b, 0.5, #5877a2, 0.5, #476999); }
+.d-button-red-background-image () { .background-image-linear-gradient-top-bottom-2-stops(#fa9d58, #ee4115, 0.5, #ff4d25, 0.5, #ed4d15); }
+.d-button-red-selected-background-image () { .background-image-linear-gradient-top-bottom-2-stops(#c1a48e, #9b6c4a, 0.5, #a27758, 0.5, #996947); }
+.d-button-checked-background-image () { .default-blue-button-background-image(); }
 
 // background styles of form controls (for gecko)
-@dui-button-background-image-gecko: -moz-linear-gradient(top, #fdfdfd 0%, #f8f8f8 50%, #eeeeee 50%, #cecece 100%);
-@dui-button-selected-background-image-gecko: -moz-linear-gradient(top, #f0f0f0 0%, #ebebeb 50%, #dedede 50%, #bfbfbf 100%);
-@dui-blue-button-background-image-gecko: @default-blue-button-background-image-gecko;
-@dui-blue-button-selected-background-image-gecko: -moz-linear-gradient(top, #8ea4c1 0%, #5877a2 50%, #476999 50%, #4a6c9b 100%);
-@dui-red-button-background-image-gecko: -moz-linear-gradient(top, #fa9d58 0%, #ff4d25 50%, #ed4d15 50%, #ee4115 100%);
-@dui-red-button-selected-background-image-gecko: -moz-linear-gradient(top, #c1a48e 0%, #a27758 50%, #996947 50%, #9b6c4a 100%);
-@dui-button-checked-background-image-gecko: @default-blue-button-background-image-gecko;
+@d-button-background-image-gecko: -moz-linear-gradient(top, #fdfdfd 0%, #f8f8f8 50%, #eeeeee 50%, #cecece 100%);
+@d-button-selected-background-image-gecko: -moz-linear-gradient(top, #f0f0f0 0%, #ebebeb 50%, #dedede 50%, #bfbfbf 100%);
+@d-button-blue-background-image-gecko: @default-blue-button-background-image-gecko;
+@d-button-blue-selected-background-image-gecko: -moz-linear-gradient(top, #8ea4c1 0%, #5877a2 50%, #476999 50%, #4a6c9b 100%);
+@d-button-red-background-image-gecko: -moz-linear-gradient(top, #fa9d58 0%, #ff4d25 50%, #ed4d15 50%, #ee4115 100%);
+@d-button-red-selected-background-image-gecko: -moz-linear-gradient(top, #c1a48e 0%, #a27758 50%, #996947 50%, #9b6c4a 100%);
+@d-button-checked-background-image-gecko: @default-blue-button-background-image-gecko;
 
 // common.less
 .mobile-body-styles () {

--- a/themes/windows/variables.less
+++ b/themes/windows/variables.less
@@ -105,24 +105,24 @@
 }
 
 // background styles of form controls
-.dui-button-background-image () {
+.d-button-background-image () {
 }
-.dui-button-selected-background-image () { .default-selected-background-image(); }
-.dui-blue-button-background-image () { .default-blue-button-background-image(); }
-.dui-blue-button-selected-background-image () { .default-selected-background-image(); }
-.dui-red-button-background-image () { .background-image-linear-gradient-top-bottom(#fa9d58, #ee4115); }
-.dui-red-button-selected-background-image () { .default-selected-background-image(); }
-.dui-button-checked-background-image () { .dui-button-background-image(); }
+.d-button-selected-background-image () { .default-selected-background-image(); }
+.d-button-blue-background-image () { .default-blue-button-background-image(); }
+.d-button-blue-selected-background-image () { .default-selected-background-image(); }
+.d-button-red-background-image () { .background-image-linear-gradient-top-bottom(#fa9d58, #ee4115); }
+.d-button-red-selected-background-image () { .default-selected-background-image(); }
+.d-button-checked-background-image () { .d-button-background-image(); }
 
 // background styles of form controls (for gecko)
-@dui-button-background-image-gecko: none;
+@d-button-background-image-gecko: none;
 @default-selected-background-image: '';
-@dui-button-selected-background-image-gecko: @default-selected-background-image;
-@dui-blue-button-background-image-gecko: @default-blue-button-background-image-gecko;
-@dui-blue-button-selected-background-image-gecko: @default-selected-background-image;
-@dui-red-button-background-image-gecko: none;
-@dui-red-button-selected-background-image-gecko: @default-selected-background-image;
-@dui-button-checked-background-image-gecko: @dui-button-background-image-gecko;
+@d-button-selected-background-image-gecko: @default-selected-background-image;
+@d-button-blue-background-image-gecko: @default-blue-button-background-image-gecko;
+@d-button-blue-selected-background-image-gecko: @default-selected-background-image;
+@d-button-red-background-image-gecko: none;
+@d-button-red-selected-background-image-gecko: @default-selected-background-image;
+@d-button-checked-background-image-gecko: @d-button-background-image-gecko;
 
 // common.less
 .mobile-body-styles () {


### PR DESCRIPTION
- fix CssState to use '-' syntax
- fix shared dui-button rules
  see issue #68

Note that the PR purpose is only to update the shared button rules so that current work on deliteful is not blocked. But as mentioned in #85, current shared theming files would need a big cleanup and refactoring to remove this wrong dependency on button rules.
