### PR TITLE
Fix issue: using a CSS style directive in a widget constructor parameter erases any style already set on the widget node in buildRendering.

### DIFF
--- a/register.js
+++ b/register.js
@@ -275,7 +275,7 @@ define([
 			// Set parameters on node
 			for (var name in params || {}) {
 				if (name === "style") {
-					node.style.cssText = params.style;
+					node.style.cssText += params.style;
 				} else {
 					node[name] = params[name];
 				}

--- a/tests/register.js
+++ b/tests/register.js
@@ -3,13 +3,20 @@ define([
 	"intern/chai!assert",
 	"../register",
 	"../Stateful",
+	"../Widget",
 	"dojo/domReady!"
-], function (registerSuite, assert, register, Stateful) {
+], function (registerSuite, assert, register, Stateful, Widget) {
 
 	// The <div> node where we will put all our DOM nodes
 	var container;
 
 	var Mixin, TestWidget, TestButtonWidget, TestExtendedWidget, TestExtendedButtonWidget;
+
+	var WidgetThatSetStyleInBuildRendering = register("styled-widget",
+													[HTMLElement, Widget],
+													{buildRendering: function () {
+														this.style.display = "block";
+													}});
 
 	var nativeButton = document.createElement("button");
 
@@ -262,7 +269,12 @@ define([
 			assert.strictEqual(1, document.getElementById("pw").createdCalls, "pw.createdCalls");
 			assert.strictEqual(1, document.getElementById("pw").startupCalls, "pw.startupCalls");
 		},
-
+		"style declared in constructor is merged with pre existing styles": function () {
+			var w = new WidgetThatSetStyleInBuildRendering({style: "height: 200px;"});
+			w.startup();
+			assert.equal(w.style.display, "block");
+			assert.equal(w.style.height, "200px");
+		},
 		teardown: function () {
 			container.parentNode.removeChild(container);
 		}


### PR DESCRIPTION
If a widget W is setting some CSS styles in its buildRendering method (for example, this.style.display = "block";), those styles settings are lost if redefining style in the argument of the constructor, as in:

```
var w = new W({style: "color: red;"});
```

because delite/register is replacing the style.cssText property of the widget node with the string declared in the constructor parameter.

I think that delite/register should add the new styles directive to the existing one instead of replacing it.
