### PR TITLE
fixes commit made for secure keys

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,8 +3,8 @@ node_js:
   - "0.10"
 env:
   global:
-    - secure: "QurZPkBBPuzahiSTqOo+Hp2DVNuajp6IlDjUcdiPBMbxXPZ+73ejbXG2m78ixyTPSLEpGkxPA4mCPPcGrJoKViYTZQ5f2bZzVOZ7XfqLqaFWiFcRIgI9gt/v15erQ7Q6Vtn8SgbpCiFrj0OdruDO7/fIOElOHZCCb0bh04Ya7Ow="
-    - secure: "G1WCqYa8ETm92bGRZO1GFpJDjnDq/AssEsVNf/D5bqi6kmc5ho/xj6jehzvwV7NzXqZyh+xXRvG0h5Sraf9C1ddpCVOnzJGhE7BuZlAvkWbJaRN5069AUb9DdQpiPvvU0FlmTfZqc2pHBD2qaFn2TGxosTU36ex4LQl927AtoSI="
+    - secure: "AAvhTgQOskU8bCPE+AmtVwvAwT6Rz99nnqvcv1GmGUjh88MOMSCCcfGUf6mn7VcCbacTYo2J9u2qi5VeOrFPdWjtuuQ9+ODt2Q7p2Xqp/41MLu6ppBoP4Ox5mlsqhFJA1u3tPsKQEOyHIMcvnGc9TH8Th/hJp5jYSyCWiaD1Kpw="
+    - secure: "GxZ1Ja3ffLG1+MmqcCKMggc6VQhrb4wjYdoO+DtTHvipbPQ4vNLDmOOyNIOJzVqOAqt68HuNpSA1b/41fDsddyEJ4VzuuPdpG77o5RUT2nE6b1coHHB3H2758zoNycQZP3LW5zi5as8NUkoh1p3yCe8CQcQ7ToSjW1KG2bE+r+M="
 
 install:
    - npm install -g grunt-cli


### PR DESCRIPTION
This _should_ fix https://github.com/ibm-js/delite/commit/93f298945d2e47bd7ec1aedb2648324c2f44765c 
I hadn't read the docs properly but it should work as I've just ran the secure keys setup against my own repo successfully, obviously I've then had to regenerate the keys using ibm's sauce account and access key matched against the delite repo
