### PR TITLE
add a new event to warn possible controller that we are going to transition, add a hide() method counterpart to the show() method.

### DIFF
--- a/DisplayContainer.js
+++ b/DisplayContainer.js
@@ -50,9 +50,9 @@ define(["dcl/dcl", "dojo/on", "dojo/Deferred", "dojo/when", "delite/Container"],
 				};
 				dcl.mix(event, params);
 				dcl.mix(event, value);
-				self.emit("delite-display-before-change", event);
+				self.emit("delite-before-show", event);
 				when(self.changeDisplay(value.child, event), function () {
-					self.emit("delite-display-complete", event);
+					self.emit("delite-after-show", event);
 					displayDeferred.resolve(value);
 				});
 			});
@@ -99,13 +99,13 @@ define(["dcl/dcl", "dojo/on", "dojo/Deferred", "dojo/when", "delite/Container"],
 				};
 				dcl.mix(event, params);
 				dcl.mix(event, value);
-				self.emit("delite-display-before-change", event);
+				self.emit("delite-before-hide", event);
 				when(self.changeDisplay(value.child, event), function () {
 					// if view is not already removed, remove it
 					if (self.getIndexOfChild(value.child) !== -1) {
 						self.removeChild(value.child);
 					}
-					self.emit("delite-display-complete", event);
+					self.emit("delite-after-hide", event);
 					displayDeferred.resolve(value);
 				});
 			});

--- a/tests/unit/DisplayContainer.js
+++ b/tests/unit/DisplayContainer.js
@@ -43,8 +43,8 @@ define([
 			transitionDeferred.then(function () {
 				testView(view1);
 				// by id
-				// test that a delite-display-complete event is fired, if is not fired the test will fail by timeout
-				on.once(dcontainer, "delite-display-complete", function () {
+				// test that a delite-after-show event is fired, if is not fired the test will fail by timeout
+				on.once(dcontainer, "delite-after-show", function () {
 					// test is finished
 					deferred.resolve(true);
 				});
@@ -76,17 +76,22 @@ define([
 			initView(view2);
 			container.appendChild(dcontainer);
 			dcontainer.startup();
+			var beforeDisplayCalled = false;
+			dcontainer.on("delite-before-hide", function () {
+				beforeDisplayCalled = true;
+			});
 			// by node
 			var transitionDeferred = dcontainer.hide(view1);
 			transitionDeferred.then(function () {
+				assert(beforeDisplayCalled, "before-hide event must be dispatched");
 				testView(view1);
 				// by id
-				// test that a delite-display-complete event is fired, if is not fired the test will fail by timeout
-				on.once(dcontainer, "delite-display-complete", function () {
+				// test that a delite-after-show event is fired, if is not fired the test will fail by timeout
+				on.once(dcontainer, "delite-after-hide", function () {
 					// test is finished
 					deferred.resolve(true);
 				});
-				transitionDeferred = dcontainer.show("view");
+				transitionDeferred = dcontainer.hide("view");
 				transitionDeferred.then(function () {
 					testView(view2);
 				});
@@ -115,13 +120,13 @@ define([
 			container.appendChild(dcontainer);
 			dcontainer.startup();
 			var beforeDisplayCalled = false;
-			dcontainer.on("delite-display-before-change", function () {
+			dcontainer.on("delite-before-show", function () {
 				beforeDisplayCalled = true;
 			});
 			// by node
 			var transitionDeferred = dcontainer.show("view1-event");
 			transitionDeferred.then(function () {
-				assert(beforeDisplayCalled, "added event must be dispatched");
+				assert(beforeDisplayCalled, "before show event must be dispatched");
 				document.removeEventListener("delite-display-load", handler);
 				deferred.resolve(true);
 			});


### PR DESCRIPTION
The new event is needed by dapp in order to notify its views that they are going to be transitionned to but they have already been added to their parent.

The hide() method is for consistency with the show() one, it perform a transition before removing the child from the parent.
