### PR TITLE
user requirejs module config API

### DIFF
--- a/theme.js
+++ b/theme.js
@@ -1,11 +1,13 @@
 define([
 	"require",
 	"dojo/has",
-	"dojo/_base/config",
+	"module",
 	"./css"		// listed here for builder, so delite/css is included into the layer
-], function (req, has, config) {
+], function (req, has, module) {
 
 	"use strict";
+
+	var config = module.config();
 
 	var load = {
 		// summary:


### PR DESCRIPTION
This PR updates `delite/theme.js` so that it uses the RequireJS module config API instead of relying on dojo config. 
For the application developper, it means code should be updated as below:

```
        require.config({
            config: {
                "delite/theme": {
                    theme: "bootstrap"
                }
            }
        });
```
