### PR TITLE
Add the job/session name of the repository to Saucelabs tests

### DIFF
--- a/tests/intern.js
+++ b/tests/intern.js
@@ -11,15 +11,15 @@ define({
 	// OnDemand. Options that will be permutated are browserName, version, platform, and platformVersion; any other
 	// capabilities options specified for an environment will be copied as-is
 	environments: [
-		{ browserName: "internet explorer", version: "11", platform: "Windows 8.1" },
-		{ browserName: "internet explorer", version: "10", platform: "Windows 8" },
+		{ browserName: "internet explorer", version: "11", platform: "Windows 8.1", name : "delite" },
+		{ browserName: "internet explorer", version: "10", platform: "Windows 8", name : "delite" },
 		// { browserName: "internet explorer", version: "9", platform: "Windows 7" },
-		{ browserName: "firefox", version: "28", platform: "Windows 7" },
-		{ browserName: "chrome", version: "33", platform: "Windows 7" },
-		{ browserName: "safari", version: "7", platform: "OS X 10.9" },
+		{ browserName: "firefox", version: "28", platform: "Windows 7", name : "delite" },
+		{ browserName: "chrome", version: "33", platform: "Windows 7", name : "delite" },
+		{ browserName: "safari", version: "7", platform: "OS X 10.9", name : "delite" },
 
 		// Mobile
-		{ browserName: "iphone", platform: "OS X 10.9", version: "7"}
+		{ browserName: "iphone", platform: "OS X 10.9", version: "7", name : "delite"}
 		// , { browserName: "android", platform: "Android" }		not currently working
 	],
 


### PR DESCRIPTION
I know this is a simple config change but if you're going to run 20+ repositories under the same Saucelabs account you need an easy way to identify the jobs in Saucelabs reports

It'll display the session name as `delite` rather than `tests/intern` (so you can identify more easily deliteful, liaison, gfx etc etc tests).
for info: there's a tags array property you can add too but I don't see the use for it
