### PR TITLE
Better way to delegate the build of delite/handlebars to require-js/text.

### DIFF
--- a/handlebars.js
+++ b/handlebars.js
@@ -1,4 +1,4 @@
-define(["requirejs-text/text", "./template"], function (text, template) {
+define(["./template"], function (text, template) {
 
 	// Text plugin to load the templates and do the build.
 	var textPlugin = "requirejs-text/text";


### PR DESCRIPTION
I don't know why I didn't think about this at the time but `pluginBuilder` is a cleaner way to delegate the build of `delite/handlebars` to `requirejs-text/text`.

This allow to simplify the load function as it will not be called by the build. The build will call the load function of requirejs text instead.
