### PR TITLE
Store: add onFetch() callback from queryStoreAndInitItems().

### DIFF
--- a/Store.js
+++ b/Store.js
@@ -129,13 +129,20 @@ define(["dcl/dcl", "dojo/when", "./Invalidating"], function (dcl, when, Invalida
 					tracked.on("remove", this._itemRemoved.bind(this));
 				}
 				collection = postProcessStore.call(this, collection);
-				// if we have a mapping function between store item and some intermediary items use it
-				return when(collection.map(function (item) {
-					return this.itemToRenderItem(item);
-				}, this)).then(this.initItems.bind(this), this._queryError.bind(this));
+				return this.onFetch(collection);
 			} else {
 				this.initItems([]);
 			}
+		},
+
+		onFetch: function (collection){
+			// summary:
+			//			Called to process the items returned after querying the store
+
+			// if we have a mapping function between store item and some intermediary items use it
+			return when(collection.map(function (item) {
+				return this.itemToRenderItem(item);
+			}, this)).then(this.initItems.bind(this), this._queryError.bind(this));
 		},
 
 		_queryError: function (error) {


### PR DESCRIPTION
This callback is intended to be overridden by classes like `Pageable` that want to process the collection bit-by-bit (one `.range()` at a time) rather than processing the whole thing at once.

(originally mentioned in #165)

I'm not sure on the naming.   Maybe processResults() or something is better

Also, perhaps the postProcessStore() method is no longer necessary as subclasses can just override onFetch().
