### PR TITLE
Gruntfile for jsdoc-amddcl.

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -109,6 +109,36 @@ module.exports = function (grunt) {
 					reporters: ["runner"]
 				}
 			}
+		},
+		"jsdoc-amddcl": {
+			delite: {
+				files: [
+					{
+						args: [
+							"-c",
+							"./node_modules/jsdoc-amddcl/conf.json"
+						],
+						src: [
+							".",
+							"./README.md",
+							"./package.json"
+						]
+					},
+					{
+						args: [
+							"-X",
+							"-c",
+							"./node_modules/jsdoc-amddcl/conf.json"
+						],
+						src: [
+							".",
+							"./README.md",
+							"./package.json"
+						],
+						dest: "./out/doclets.json"
+					}
+				]
+			}
 		}
 	});
 	// Load plugins
@@ -116,6 +146,7 @@ module.exports = function (grunt) {
 	grunt.loadNpmTasks("grunt-contrib-jshint");
 	grunt.loadNpmTasks("grunt-contrib-less");
 	grunt.loadNpmTasks("grunt-contrib-uglify");
+	grunt.loadNpmTasks("jsdoc-amddcl");
 	grunt.loadTasks("themes/tasks");// Custom cssToJs task to convert CSS to JS
 
 	grunt.registerTask("css", ["less", "cssToJs"]);

--- a/package.json
+++ b/package.json
@@ -8,7 +8,8 @@
 		"grunt": "~0.4.2",
 		"grunt-contrib-jshint": "~0.6.3",
 		"grunt-contrib-less": "~0.8.3",
-		"grunt-contrib-uglify": "~0.2.2"
+		"grunt-contrib-uglify": "~0.2.2",
+		"jsdoc-amddcl": "git://github.com/ibm-js/jsdoc-amddcl#master"
 	},
 	"licenses": [
 		{


### PR DESCRIPTION
Grunt config for jsdoc-amddcl. To use it:

``` shellsession
> npm install
> grunt jsdoc-amddcl
```

The documents as well as exported doclets will be found in “out” directory.

To use syntax highlighting, you’ll need to manually install prettify, following the instruction [here](https://github.com/ibm-js/jsdoc-amddcl/#setup).

Also, `npm update` does not seem to grab updates in git://github.com/ibm-js/jsdoc-amddcl.git#master. You can do below to grab updates:

``` shellshession
> rm -Rf node_modules/jsdoc-amddcl
> npm install git://github.com/ibm-js/jsdoc-amddcl.git
```
