### PR TITLE
rework Store architecture based on SitePen/dstore#5

### DIFF
--- a/tests/unit/Store.js
+++ b/tests/unit/Store.js
@@ -131,28 +131,30 @@ define([
 		"StoreFuncRange": function () {
 			var d = this.async(1500);
 			var store = new C();
-			store.preProcessStore = function (store) {
-				return store.range(1);
-			};
+			store.startIndex = 1;
+			store.endIndex = 2;
 			var myData = [
 				{ id: "foo", name: "Foo" },
-				{ id: "bar", name: "Bar" }
+				{ id: "bar", name: "Bar" },
+				{ id: "xx", name: "Bar" },
+				{ id: "zz", name: "Bar" }
 			];
 			store.on("query-success", d.callback(function () {
 				assert(store.renderItems instanceof Array);
-				// TODO: actual tests are commented out pending SitePen/dstore#5
-				// TODO: once fixed also add postProcessStore tests
-				//assert.equal(store.renderItems.length, 1);
+				assert.equal(store.renderItems.length, 1);
 				myStore.put({ id: "foo", name: "Foo2" });
 				// this works because put is synchronous & same for add etc...
-				//assert.equal(store.renderItems.length, 1);
-				//assert.deepEqual(store.renderItems[0], { id: "foo", name: "Foo2" });
+				assert.equal(store.renderItems.length, 1);
+				assert.deepEqual(store.renderItems[0], { id: "bar", name: "Bar" });
 				myStore.add({ id: "fb", name: "FB" });
-				//assert.equal(store.renderItems.length, 1);
-				//assert.deepEqual(store.renderItems[0], { id: "foo", name: "Foo2" });
-				myStore.remove("bar");
-				//assert.equal(store.renderItems.length, 1);
-				//assert.deepEqual(store.renderItems[0], { id: "foo", name: "Foo2" });
+				assert.equal(store.renderItems.length, 1);
+				assert.deepEqual(store.renderItems[0], { id: "bar", name: "Bar" });
+				myStore.put({ id: "bar", name: "Bar2" });
+				assert.equal(store.renderItems.length, 1);
+				assert.deepEqual(store.renderItems[0], { id: "bar", name: "Bar2" });
+				myStore.remove("foo");
+				assert.equal(store.renderItems.length, 1);
+				assert.deepEqual(store.renderItems[0], { id: "bar", name: "Bar2" });
 			}));
 			store.startup();
 			// use empty model to easy comparison
@@ -163,7 +165,7 @@ define([
 		"StoreFuncSort": function () {
 			var d = this.async(1500);
 			var store = new C();
-			store.preProcessStore = function (store) {
+			store.processStore = function (store) {
 				return store.sort("index");
 			};
 			var myData = [


### PR DESCRIPTION
This PR is changing a bit the design of delite/Store to comply with what was mentionned in SitePen/dstore#5.

In particular:
- range should always be called post track
- notification can come from outside the range

For that postProcessStore is replaced by start & end range index and the notification mechanism is checking if the notification comes from items inside the range before:
1. continuing with notification only if the change is in the range
2. changing the notification index to be based on the range start index

I'm particularly interested in @sbrunot feedback on whether this would be fine with `delite/list/List`?
