### PR TITLE
Rewrite DialogUnderlay

### DIFF
--- a/DialogUnderlay/themes/DialogUnderlay_template.less
+++ b/DialogUnderlay/themes/DialogUnderlay_template.less
@@ -1,0 +1,14 @@
+// Template for DialogUnderlay CSS, included from themes/*/DialogUnderlay.less files
+
+.d-dialog-underlay {
+	// These values shouldn't be adjusted.
+	display: block;
+	position: fixed;
+	left: 0;
+	top: 0;
+	z-index: 998;
+
+	// These can change based on the theme.
+	background: @dialog-underlay-background;
+	opacity: 0.5;
+}

--- a/DialogUnderlay/themes/bootstrap/DialogUnderlay_css.js
+++ b/DialogUnderlay/themes/bootstrap/DialogUnderlay_css.js
@@ -1,0 +1,15 @@
+define(function () {
+	/* jshint multistr: true */
+	/* jshint -W015 */
+	/* jshint -W033 */
+	return "\
+.d-dialog-underlay {\
+  display: block;\
+  position: fixed;\
+  left: 0;\
+  top: 0;\
+  z-index: 998;\
+  background: #ffffff;\
+  opacity: 0.5;\
+}";
+});

--- a/DialogUnderlay/themes/holodark/DialogUnderlay_css.js
+++ b/DialogUnderlay/themes/holodark/DialogUnderlay_css.js
@@ -1,0 +1,15 @@
+define(function () {
+	/* jshint multistr: true */
+	/* jshint -W015 */
+	/* jshint -W033 */
+	return "\
+.d-dialog-underlay {\
+  display: block;\
+  position: fixed;\
+  left: 0;\
+  top: 0;\
+  z-index: 998;\
+  background: #000000;\
+  opacity: 0.5;\
+}";
+});

--- a/DialogUnderlay/themes/ios/DialogUnderlay_css.js
+++ b/DialogUnderlay/themes/ios/DialogUnderlay_css.js
@@ -1,0 +1,15 @@
+define(function () {
+	/* jshint multistr: true */
+	/* jshint -W015 */
+	/* jshint -W033 */
+	return "\
+.d-dialog-underlay {\
+  display: block;\
+  position: fixed;\
+  left: 0;\
+  top: 0;\
+  z-index: 998;\
+  background: #777777;\
+  opacity: 0.5;\
+}";
+});

--- a/tests/functional/DialogUnderlay.html
+++ b/tests/functional/DialogUnderlay.html
@@ -1,0 +1,142 @@
+<!DOCTYPE HTML>
+<html>
+<head>
+	<meta http-equiv="content-type" content="text/html; charset=utf-8"/>
+	<meta name="viewport"
+		  content="width=device-width,initial-scale=1,maximum-scale=1,minimum-scale=1,user-scalable=no"/>
+	<meta name="apple-mobile-web-app-capable" content="yes"/>
+	<title>DialogUnderlay Test</title>
+	<script type="text/javascript" src="../boilerplate.js"></script>
+	<script language="JavaScript" type="text/javascript">
+		var ready = false; // set to true when the test page is ready
+
+		var clicks = 0;
+
+		require([
+			"delite/DialogUnderlay",
+			"requirejs-domReady/domReady!"
+		], function (du) {
+			// set global so button code can access it
+			DialogUnderlay = du;
+
+			// Set global variable to signal that the test page is ready
+			ready = true;
+		})
+	</script>
+</head>
+<body>
+	<h1>DialogUnderlay functional test</h1>
+
+	<button type=button onclick="this.innerHTML = 'clicked ' + ++clicks + ' times';">clicked 0 times</button>
+	<div style="position: fixed; z-index: 1000; border: 2px solid gray; background: #ddd;">
+		<p>(This is a fixed div at z-index: 1000)</p>
+
+		<button onclick="DialogUnderlay.show({}, 950);">show underlay (z-index: 950)</button>
+		<button onclick="DialogUnderlay.hide();">hide underlay</button>
+		<br>
+
+		<label for="showLorem">Show Lorem text:</label>
+		<input id="showLorem" type="checkbox" onchange="lorem.style.display = this.checked ? 'block' : 'none';">
+		(makes document longer than viewport)
+	</div>
+
+	<div id="lorem" style="display: none">
+		<p>Aliquam vitae enim. Duis scelerisque metus auctor est venenatis
+			imperdiet. Fusce dignissim porta augue. Nulla vestibulum. Integer lorem
+			nunc, ullamcorper a, commodo ac, malesuada sed, dolor. Aenean id mi in
+			massa bibendum suscipit. Integer eros. Nullam suscipit mauris. In
+			pellentesque. Mauris ipsum est, pharetra semper, pharetra in, viverra
+			quis, tellus. Etiam purus. Quisque egestas, tortor ac cursus lacinia,
+			felis leo adipiscing nisi, et rhoncus elit dolor eget eros. Fusce ut
+			quam. Suspendisse eleifend leo vitae ligula. Nulla facilisi. Nulla
+			rutrum, erat vitae lacinia dictum, pede purus imperdiet lacus, ut
+			semper velit ante id metus. Praesent massa dolor, porttitor sed,
+			pulvinar in, consequat ut, leo. Nullam nec est. Aenean id risus blandit
+			tortor pharetra congue. Suspendisse pulvinar.
+		</p>
+		<p>Vestibulum convallis eros ac justo. Proin dolor. Etiam aliquam. Nam
+			ornare elit vel augue. Suspendisse potenti. Etiam sed mauris eu neque
+			nonummy mollis. Vestibulum vel purus ac pede semper accumsan. Vivamus
+			lobortis, sem vitae nonummy lacinia, nisl est gravida magna, non cursus
+			est quam sed urna. Phasellus adipiscing justo in ipsum. Duis sagittis
+			dolor sit amet magna. Suspendisse suscipit, neque eu dictum auctor,
+			nisi augue tincidunt arcu, non lacinia magna purus nec magna. Praesent
+			pretium sollicitudin sapien. Suspendisse imperdiet. Class aptent taciti
+			sociosqu ad litora torquent per conubia nostra, per inceptos
+			hymenaeos.
+		</p>
+		<p>Aliquam vitae enim. Duis scelerisque metus auctor est venenatis
+			imperdiet. Fusce dignissim porta augue. Nulla vestibulum. Integer lorem
+			nunc, ullamcorper a, commodo ac, malesuada sed, dolor. Aenean id mi in
+			massa bibendum suscipit. Integer eros. Nullam suscipit mauris. In
+			pellentesque. Mauris ipsum est, pharetra semper, pharetra in, viverra
+			quis, tellus. Etiam purus. Quisque egestas, tortor ac cursus lacinia,
+			felis leo adipiscing nisi, et rhoncus elit dolor eget eros. Fusce ut
+			quam. Suspendisse eleifend leo vitae ligula. Nulla facilisi. Nulla
+			rutrum, erat vitae lacinia dictum, pede purus imperdiet lacus, ut
+			semper velit ante id metus. Praesent massa dolor, porttitor sed,
+			pulvinar in, consequat ut, leo. Nullam nec est. Aenean id risus blandit
+			tortor pharetra congue. Suspendisse pulvinar.
+		</p>
+		<p>Vestibulum convallis eros ac justo. Proin dolor. Etiam aliquam. Nam
+			ornare elit vel augue. Suspendisse potenti. Etiam sed mauris eu neque
+			nonummy mollis. Vestibulum vel purus ac pede semper accumsan. Vivamus
+			lobortis, sem vitae nonummy lacinia, nisl est gravida magna, non cursus
+			est quam sed urna. Phasellus adipiscing justo in ipsum. Duis sagittis
+			dolor sit amet magna. Suspendisse suscipit, neque eu dictum auctor,
+			nisi augue tincidunt arcu, non lacinia magna purus nec magna. Praesent
+			pretium sollicitudin sapien. Suspendisse imperdiet. Class aptent taciti
+			sociosqu ad litora torquent per conubia nostra, per inceptos
+			hymenaeos.
+		</p>
+		<p>Aliquam vitae enim. Duis scelerisque metus auctor est venenatis
+			imperdiet. Fusce dignissim porta augue. Nulla vestibulum. Integer lorem
+			nunc, ullamcorper a, commodo ac, malesuada sed, dolor. Aenean id mi in
+			massa bibendum suscipit. Integer eros. Nullam suscipit mauris. In
+			pellentesque. Mauris ipsum est, pharetra semper, pharetra in, viverra
+			quis, tellus. Etiam purus. Quisque egestas, tortor ac cursus lacinia,
+			felis leo adipiscing nisi, et rhoncus elit dolor eget eros. Fusce ut
+			quam. Suspendisse eleifend leo vitae ligula. Nulla facilisi. Nulla
+			rutrum, erat vitae lacinia dictum, pede purus imperdiet lacus, ut
+			semper velit ante id metus. Praesent massa dolor, porttitor sed,
+			pulvinar in, consequat ut, leo. Nullam nec est. Aenean id risus blandit
+			tortor pharetra congue. Suspendisse pulvinar.
+		</p>
+		<p>Vestibulum convallis eros ac justo. Proin dolor. Etiam aliquam. Nam
+			ornare elit vel augue. Suspendisse potenti. Etiam sed mauris eu neque
+			nonummy mollis. Vestibulum vel purus ac pede semper accumsan. Vivamus
+			lobortis, sem vitae nonummy lacinia, nisl est gravida magna, non cursus
+			est quam sed urna. Phasellus adipiscing justo in ipsum. Duis sagittis
+			dolor sit amet magna. Suspendisse suscipit, neque eu dictum auctor,
+			nisi augue tincidunt arcu, non lacinia magna purus nec magna. Praesent
+			pretium sollicitudin sapien. Suspendisse imperdiet. Class aptent taciti
+			sociosqu ad litora torquent per conubia nostra, per inceptos
+			hymenaeos.
+		</p>
+		<p>Aliquam vitae enim. Duis scelerisque metus auctor est venenatis
+			imperdiet. Fusce dignissim porta augue. Nulla vestibulum. Integer lorem
+			nunc, ullamcorper a, commodo ac, malesuada sed, dolor. Aenean id mi in
+			massa bibendum suscipit. Integer eros. Nullam suscipit mauris. In
+			pellentesque. Mauris ipsum est, pharetra semper, pharetra in, viverra
+			quis, tellus. Etiam purus. Quisque egestas, tortor ac cursus lacinia,
+			felis leo adipiscing nisi, et rhoncus elit dolor eget eros. Fusce ut
+			quam. Suspendisse eleifend leo vitae ligula. Nulla facilisi. Nulla
+			rutrum, erat vitae lacinia dictum, pede purus imperdiet lacus, ut
+			semper velit ante id metus. Praesent massa dolor, porttitor sed,
+			pulvinar in, consequat ut, leo. Nullam nec est. Aenean id risus blandit
+			tortor pharetra congue. Suspendisse pulvinar.
+		</p>
+		<p>Vestibulum convallis eros ac justo. Proin dolor. Etiam aliquam. Nam
+			ornare elit vel augue. Suspendisse potenti. Etiam sed mauris eu neque
+			nonummy mollis. Vestibulum vel purus ac pede semper accumsan. Vivamus
+			lobortis, sem vitae nonummy lacinia, nisl est gravida magna, non cursus
+			est quam sed urna. Phasellus adipiscing justo in ipsum. Duis sagittis
+			dolor sit amet magna. Suspendisse suscipit, neque eu dictum auctor,
+			nisi augue tincidunt arcu, non lacinia magna purus nec magna. Praesent
+			pretium sollicitudin sapien. Suspendisse imperdiet. Class aptent taciti
+			sociosqu ad litora torquent per conubia nostra, per inceptos
+			hymenaeos.
+		</p>
+	</div>
+</body>
+</html>


### PR DESCRIPTION
Rewrite DialogUnderlay, add manual test, and remove dojo/window and dojo/on dependencies.

This came about because I'm trying to remove dojo/core dependencies from delite.   And this is the part that can be done w/out jQuery.

DialogUnderlay still needs a functional test, but perhaps that should be delayed until the DialogLevelManager is ported too.
