### PR TITLE
pass Function parameters when using markup

### DIFF
--- a/Selection.js
+++ b/Selection.js
@@ -263,6 +263,6 @@ define(["dcl/dcl", "./sniff", "./Widget"], function (dcl, has, Widget) {
 		/**
 		 * Hook for selection-change event in markup.
 		 */
-		"onselection-change": function () {}
+		"onselection-change": function (/*jshint unused: vars*/event) {}
 	});
 });

--- a/StoreMap.js
+++ b/StoreMap.js
@@ -105,13 +105,23 @@ define(["dcl/dcl", "dojo/_base/lang", "./Store"], function (dcl, lang, Store) {
 					if (name.lastIndexOf("Attr") === name.length - 4) {
 						this[name] = value;
 					} else {
-						/* jshint evil:true */
-						// This will be executed only if you use StoreMap mapping by function in your tag attributes:
-						// <my-tag labelFunc="myfunc"></my-tag>
-						// This can be avoided by using mapping by function progammatically or by not using it at all.
-						// This is harmless if you make sure the JavaScript code that is passed to the attribute
-						// is harmless.
-						this[name] = lang.getObject(value, false, global) || new Function(value);
+						this[name] = lang.getObject(value, false, global);
+						if (!this[name]) {
+							var functionString = this[name].toString().replace(/(\/\*([\s\S]*?)\*\/)|(\/\/(.*)$)/gm,
+								"");
+							var functionArgs = functionString.match(/^function\s*[^\(]*\(\s*([^\)]*)\)/m)[1].split();
+							functionArgs.unshift(undefined);
+							functionArgs.push(value);
+							/* jshint evil:true */
+							// This will be executed only if you use StoreMap mapping by function in your tag 
+							// attributes as follows:
+							// <my-tag labelFunc="return item.x"></my-tag>
+							// This can be avoided by using mapping by function progammatically or by not using it at 
+							// all.
+							// This is harmless if you make sure the JavaScript code that is passed to the attribute
+							// is harmless.
+							this[name] = new (Function.bind.apply(Function, functionArgs))();
+						}
 					}
 				}
 			}

--- a/tests/unit/CustomElement.js
+++ b/tests/unit/CustomElement.js
@@ -34,12 +34,14 @@ define([
 				},
 				funcProp2: function () {
 				},
+				funcPropWithParams: function (/*jshint unused: vars*//*a 1st param*/param1,
+					/* and a second one */param2) {},
 				objProp1: { },
 				objProp2: { }
 			});
 			container.innerHTML +=
 				"<test-ce-declarative id='d' boolProp='boolProp' numProp='5' stringProp='hello' " +
-				"funcProp='global=123;' funcProp2='global3' objProp1='foo:1,bar:2' objProp2='global2'/>";
+				"funcProp='global=123;' funcProp2='global3' funcPropWithParams='global=param1+param2' objProp1='foo:1,bar:2' objProp2='global2'/>";
 			var d = document.getElementById("d");
 			register.upgrade(d);
 			assert.isTrue(d.boolProp, "d.boolProp");
@@ -50,6 +52,8 @@ define([
 			assert.strictEqual(global, 123, "d.funcProp() executed");
 			d.funcProp2();
 			assert.strictEqual(global, 456, "d.funcProp2() executed");
+			d.funcPropWithParams(1, 2);
+			assert.strictEqual(global, 3, "d.funcPropWithParams() executed");
 			assert.strictEqual(d.objProp1.foo, 1, "d.objProp1.foo");
 			assert.strictEqual(d.objProp1.bar, 2, "d.objProp1.bar");
 			assert.strictEqual(d.objProp2.text, "global var", "d.objProp2.text");


### PR DESCRIPTION
When using markup, you can put some JavaScript in the attribute corresponding to a property of type function. Something like the following:

``` html
<my-tag funcAttr="console.log('hello')"></my-tag>
```

and the function will correctly be called.

However imagine that your function has the following signature:

``` js
dcl(Widget, {
   funcAttr: function(param) {
   }
});
```

You don't get access to "param", meaning you can't do:

``` html
<my-tag funcAttr="console.log(attr)"></my-tag>
```

This is particularly annoying for event where for example you would like to be able to do something like the following:

``` html
<d-list onselection-change="myviewstack.show(event.newValue"></d-list>
```

This PR is making sure the Function is built with the right parameters so you can do that. 
