### PR TITLE
Fix blocking regression with templates build introduced by fixing a bug in grunt-amd-build.

### DIFF
--- a/handlebars.js
+++ b/handlebars.js
@@ -33,7 +33,7 @@
  *
  * @module delite/handlebars
  */
-define(["requirejs-text/text", "./template"], function (text, template) {
+define(["./template"], function (template) {
 
 	// Text plugin to load the templates and do the build.
 	var textPlugin = "requirejs-text/text";
@@ -284,8 +284,10 @@ define(["requirejs-text/text", "./template"], function (text, template) {
 		 * @private
 		 */
 		write: function (pluginName, moduleName, write, loaderConfig) {
-			// summary:
-			//		Used by builds
+			// Requirejs-text is not listed in the dependency list so it is not
+			// included in the layer. At build time requirejs works synchronously so
+			// there is no callback.
+			var text = require(textPlugin);
 			text.write(textPlugin, moduleName, write, loaderConfig);
 		}
 	};


### PR DESCRIPTION
The `pluginBuilder` API was working before in this case, but only because of a bug in `grunt-amd-build`.

Using `pluginBuilder` will inline the following code in the layer:

```
define("delite/handlebars!path/to/template.html", "template string");
```

The problem is, when requirejs see this it will not use the load method of `delite/handlebars` but directly return `template string`.

After this PR the build output:

```
define("requirejs-text/text!path/to/template.html", "template string");
```

This way the template will still be compiled even if the code is built.
