### PR TITLE
FormValueWidget: don't fire change event unless user actually changes the value

### DIFF
--- a/tests/unit/FormValueWidget.js
+++ b/tests/unit/FormValueWidget.js
@@ -16,25 +16,64 @@ define([
 		beforeEach: function () {
 			container = document.createElement("div");
 			document.body.appendChild(container);
-			widget = new FormValueWidgetTest().placeAt(container);
+			widget = new FormValueWidgetTest({
+				value: "original value"
+			}).placeAt(container);
 			widget.startup();
 		},
 
 		handleOnInput: function () {
 			var d = this.async(3000);
-			container.addEventListener("input", d.callback(function (e) {
-				assert.strictEqual(e.type, "input");
+
+			var log = [];
+			container.addEventListener("input", d.rejectOnError(function (e) {
+				log.push(widget.value);
 			}));
-			widget.handleOnInput("input value");
+
+			widget.value = "input value 0";
+			widget._onFocus();
+			widget.handleOnInput("input value 1");
+			widget.handleOnInput("input value 2");
+			widget.handleOnInput("input value 3");
+
+			setTimeout(d.callback(function (e){
+				// test debouncing; should only get one notification, about the latest value
+				assert.deepEqual(log, ["input value 3"]);
+			}), 100);
+
 			return d;
 		},
 
 		handleOnChange: function () {
 			var d = this.async(3000);
+
 			container.addEventListener("change", d.callback(function (e) {
 				assert.strictEqual(e.type, "change");
 			}));
+
+			widget.value = "initial value";
+			widget._onFocus();
 			widget.handleOnChange("change value");
+
+			return d;
+		},
+
+		// Test corner case where user sets value to same thing it was originally, by dragging a slider
+		// handle but returning it to its original position before pointerup.
+		noChange: function () {
+			var d = this.async(3000);
+			container.addEventListener("change", d.rejectOnError(function (e) {
+				throw new Error("got change event");
+			}));
+
+			widget.value = "initial value";
+			widget._onFocus();
+			widget.handleOnChange("initial value");
+
+			setTimeout(d.callback(function (){
+				// if this timeout fires without seeing any change event, we are good
+			}), 100);
+
 			return d;
 		},
 


### PR DESCRIPTION
This is for the corner case when the user (for example) drags the slider handle
but drags it back to its original position before mouseup.

This handles the case when the widget value was set programatically sometime after
startup(), and also the case when the value is computed asynchronously after the startup()
call.

Refs ibm-js/deliteful#199.
