### PR TITLE
Ensure Widget's baseClass (CSS) is already set at the end of parsing

### DIFF
--- a/Widget.js
+++ b/Widget.js
@@ -111,6 +111,15 @@ define([
 		attachedCallback: function () {
 			this._attached = true;
 
+			// Ensure these CSS classes are set synchronously. 
+			// Also set asynchronously in refreshRendering().
+			if (this.baseClass) {
+				domClass.add(this, this.baseClass);
+			}
+			if (!this.isLeftToRight()) {
+				domClass.add(this, "d-rtl");
+			}
+			
 			// Since safari masks all custom setters for tabIndex on the prototype, call them here manually.
 			// For details see:
 			//		https://bugs.webkit.org/show_bug.cgi?id=36423

--- a/tests/unit/Widget.js
+++ b/tests/unit/Widget.js
@@ -187,6 +187,13 @@ define([
 			myWidgetCustom.deliver();
 
 			assert(domClass.contains(myWidgetCustom, "customBase"), "baseClass is customBase");
+			
+			// Check that, in the markup case, the base class is already set after parsing. 
+			var html = "<test-lifecycle-widget2 id='widgetForTestingBaseClass'></test-lifecycle-widget2>";
+			container.innerHTML = html;
+			register.parse(container);
+			var w = document.getElementById("widgetForTestingBaseClass");
+			assert(domClass.contains(w, "base2"), "baseClass is base2 in markup case");
 		},
 
 		startup: function () {


### PR DESCRIPTION
See https://github.com/ibm-js/delite/issues/271 .
