### PR TITLE
FormWidget: Move aria attributes to this.focusNode.

### DIFF
--- a/tests/unit/FormWidget.js
+++ b/tests/unit/FormWidget.js
@@ -1,0 +1,65 @@
+define([
+	"intern!object",
+	"intern/chai!assert",
+	"delite/register",
+	"delite/FormWidget"
+], function (registerSuite, assert, register, FormWidget) {
+	var container, FormWidgetTest;
+
+	registerSuite({
+		name: "FormWidget",
+
+		setup: function () {
+			FormWidgetTest = register("form-widget-test", [HTMLElement, FormWidget], {
+				buildRendering: function () {
+					this.focusNode = this.ownerDocument.createElement("input");
+					this.appendChild(this.focusNode);
+				}
+			});
+		},
+
+		beforeEach: function () {
+			container = document.createElement("div");
+			document.body.appendChild(container);
+		},
+
+		// Test that aria attributes are moved to the focus node
+		aria: function () {
+			// Create a widget declaratively to test initial aria attributes processed
+			container.innerHTML = "<form-widget-test aria-label='test label' foo='bar'></form-widget-test>";
+			register.parse(container);
+
+			var myWidget = container.firstChild;
+
+			// Check that aria-label was moved
+			assert.strictEqual(myWidget.attributes.length, 1, "aria-label removed from root");
+			assert.strictEqual(myWidget.focusNode.getAttribute("aria-label"), "test label",
+				"aria-label added to focusNode");
+			
+
+			// Test that setAttribute(), removeAttribute(), hasAttribute(), and getAttribute() all redirect to the
+			// focus node when appropriate
+			assert(myWidget.hasAttribute("foo"), "hasAttribute(foo)");
+			assert(myWidget.hasAttribute("aria-label"), "hasAttribute(aria-label)");
+			assert.isFalse(myWidget.hasAttribute("bar"), "hasAttribute(bar)");
+
+			assert.strictEqual(myWidget.getAttribute("foo"), "bar", "getAttribute(foo)");
+			assert.strictEqual(myWidget.getAttribute("aria-label"), "test label", "getAttribute(aria-label)");
+
+			myWidget.removeAttribute("foo");
+			assert.isFalse(myWidget.hasAttribute("foo"), "foo removed");
+			myWidget.removeAttribute("aria-label");
+			assert.isFalse(myWidget.hasAttribute("aria-label"), "hasAttribute(aria-label)");
+
+			myWidget.setAttribute("foo", "bar 2");
+			myWidget.setAttribute("aria-label", "label 2");
+			assert.strictEqual(myWidget.attributes.length, 1, "root has foo but not aria-label");
+			assert.strictEqual(myWidget.focusNode.getAttribute("aria-label"), "label 2",
+				"aria-label added to focusNode");
+		},
+
+		afterEach: function () {
+			container.parentNode.removeChild(container);
+		}
+	});
+});

--- a/tests/unit/all.js
+++ b/tests/unit/all.js
@@ -16,5 +16,6 @@ define([
 	"./Store",
 	"./Scrollable",
 	"./KeyNav",
+	"./FormWidget",
 	"./FormValueWidget"
 ]);


### PR DESCRIPTION
Handles attributes specified declaratively at widget creation time,
plus set programatically (at any time) via setAttribute().

Also overrides getAttribute(), hasAttribute(), and removeAttribute()
to make it appear that the aria attributes are set on the widget root node.
The abstraction is leaky though because myWidget.attributes will reflect
the true attributes set on the root node.

Fixes #193.
