### PR TITLE
Fix two issues with clean-css and delite/css.

### DIFF
--- a/css.js
+++ b/css.js
@@ -193,13 +193,22 @@ define([
 
 				if (CleanCSS) {
 					var result = "";
-					loadList = loadList.map(require.toUrl);
+					loadList = loadList.map(require.toUrl)
+						.filter(function (path) {
+							var fs = require.nodeRequire("fs");
+							if (!fs.existsSync(path)) {
+								console.log(">> Css file '" + path + "' was not found.");
+								return false;
+							}
+							return true;
+						});
 					loadList.forEach(function (src) {
 						result += new CleanCSS({
 							relativeTo: "./",
 							target: dest
 						}).minify("@import url(" + src + ");");
 					});
+
 					writePluginFiles(dest, result);
 				} else {
 					console.log(">> Node module clean-css not found. Skipping CSS inlining. If you want CSS inlining" +


### PR DESCRIPTION
This PR fix issues #274 and #275 and add better log messages in case of failure.

There is now a message if `clean-css` is not found and since it is not a critical failure, the build will continue without processing the CSS files.

There is also a message if a required CSS file is not found.
