### PR TITLE
forward keystrokes from HasDropDown to dropdown via emit() 

### DIFF
--- a/HasDropDown.js
+++ b/HasDropDown.js
@@ -303,8 +303,8 @@ define([
 				return;
 			}
 			var dropDown = this._currentDropDown, target = e.target;
-			if (dropDown && this.opened && dropDown.handleKey) {
-				if (dropDown.handleKey(e) === false) {
+			if (dropDown && this.opened) {
+				if (dropDown.emit("keydown", e) === false) {
 					/* false return code means that the drop down handled the key */
 					e.stopPropagation();
 					e.preventDefault();

--- a/tests/functional/HasDropDown.html
+++ b/tests/functional/HasDropDown.html
@@ -138,7 +138,11 @@
 					child.className = "selected";
 				},
 
-				handleKey: function (evt) {
+				postRender: function () {
+					this.on("keydown", this._keydownHandler.bind(this));
+				},
+
+				_keydownHandler: function (evt) {
 					if(evt.keyCode == keys.ENTER || evt.keyCode == keys.SPACE) {
 						this.emit("change");
 						this.selected.className = "";


### PR DESCRIPTION
Currently when the dropdown is open but the focus is on the host widget, the host widget forwards keystrokes to the popup by calling the popup's handleKey() method (if such a method is defined).

It seems more standard to do that with events, specifically by emitting a keydown event on the popup, and then if the popup calls evt.preventDefault() it means that it handled the keystroke; otherwise it means that the host widget should handle it.

It's in line with how activationTracker tells widgets that they have become activate/inactivate by firing delite-activated and delite-deactivated events.
