### PR TITLE
Use local require in delite/handlebars write method instead of global require

### DIFF
--- a/handlebars.js
+++ b/handlebars.js
@@ -33,7 +33,7 @@
  *
  * @module delite/handlebars
  */
-define(["./Template"], function (Template) {
+define(["./Template", "require"], function (Template, require) {
 
 	// Text plugin to load the templates and do the build.
 	var textPlugin = "requirejs-text/text";


### PR DESCRIPTION
Since https://github.com/ibm-js/grunt-amd-build/commit/664a58e758a959b611d1b57204503f0fb323a33a, `grunt-amd-build` is creating one requirejs context by layer. Because of that, the local require and the global require are no longer equivalent and to achieve layer isolation, plugins should only use the local require.

This commit changes the global require from [ibm-js/delite/handlebars.js#L306 ](https://github.com/ibm-js/delite/blob/master/handlebars.js#L306) to a local require.
