### PR TITLE
JSDoc: move @event to beginning of module and add @fires

### DIFF
--- a/CustomElement.js
+++ b/CustomElement.js
@@ -5,7 +5,17 @@ define([
 	"decor/Destroyable",
 	"decor/Stateful"
 ], function (dcl, Observable, Destroyable, Stateful) {
-
+	/**
+	 * Dispatched after the CustomElement has been attached.
+	 * This is useful to be notified when an HTMLElement has been upgraded to a
+	 * CustomElement and attached to the DOM, in particular on browsers supporting native Custom Element.
+	 * @example
+	 * element.addEventListener("customelement-attached", function (evt) {
+	 *      console.log("custom element: "+evt.target.id+" has been attached");
+	 * });
+	 * @event module:delite/CustomElement.customelement-attached
+	 */
+	
 	/**
 	 * Get a property from a dot-separated string, such as "A.B.C".
 	 */
@@ -119,19 +129,10 @@ define([
 		 * This method is automatically chained, so subclasses generally do not need to use `dcl.superCall()`,
 		 * `dcl.advise()`, etc.
 		 * @method
+		 * @fires module:delite/CustomElement.customelement-attached
 		 */
 		attachedCallback: dcl.after(function () {
 			this.attached = true;
-			/**
-			 * Dispatched after the CustomElement has been attached.
-			 * This is useful to be notified when an HTMLElement has been upgraded to a
-			 * CustomElement and attached to the DOM, in particular on browsers supporting native Custom Element.
-			 * @example
-			 * element.addEventListener("customelement-attached", function (evt) {
-			 *      console.log("custom element: "+evt.target.id+" has been attached");
-			 * });
-			 * @event module:delite/CustomElement.customelement-attached
-			 */
 			this.emit("customelement-attached", {
 				bubbles: false,
 				cancelable: false

--- a/DisplayContainer.js
+++ b/DisplayContainer.js
@@ -1,6 +1,64 @@
 /** @module delite/DisplayContainer */
 define(["dcl/dcl", "dojo/Deferred", "dojo/when", "delite/Container"],
 	function (dcl, Deferred, when, Container) {
+
+	/**
+	 * Dispatched before child is shown.
+	 * @example
+	 * document.addEventListener("delite-before-show", function (evt) {
+	 *      console.log("about to show child", evt.child);
+	 * });
+	 * @event module:delite/DisplayContainer.delite-before-show
+	 * @property {Element} child - reference to child element
+	 */
+	
+	/**
+	 * Dispatched after child is shown.
+	 * @example
+	 * document.addEventListener("delite-after-show", function (evt) {
+	 *      console.log("just displayed child", evt.child);
+	 * });
+	 * @event module:delite/DisplayContainer.delite-after-show
+	 * @property {Element} child - reference to child element
+	 */
+	
+	/**
+	 * Dispatched to let an application level listener create/load the child node.
+	 * @example
+	 * document.addEventListener("delite-display-load", function (evt) {
+	 *     // fetch the data for the specified id, then create a node with that data
+	 *     var def = evt.loadDeferred;
+	 *     fetchData(evt.dest).then(function(data) {
+	 *         var child = document.createElement("div");
+	 *         child.innerHTML = data;
+	 *         def.resolve({child: child});
+	 *     });
+	 *     evt.preventDefault();
+	 * });
+	 * @event module:delite/DisplayContainer.delite-display-load
+	 * @property {Promise} loadDeferred - promise to resolve with the child element
+	 */
+	
+	/**
+	 * Dispatched before child is hidden.
+	 * @example
+	 * document.addEventListener("delite-before-hide", function (evt) {
+	 *      console.log("about to hide child", evt.child);
+	 * });
+	 * @event module:delite/DisplayContainer.delite-before-hide
+	 * @property {Element} child - reference to child element
+	 */
+	
+	/**
+	 * Dispatched after child is hidden.
+	 * @example
+	 * document.addEventListener("delite-after-hide", function (evt) {
+	 *      console.log("just hid child", evt.child);
+	 * });
+	 * @event module:delite/DisplayContainer.delite-after-hide
+	 * @property {Element} child - reference to child element
+	 */
+		
 	/**
 	 * Mixin for widget containers that need to show on or off a child.
 	 *
@@ -20,6 +78,9 @@ define(["dcl/dcl", "dojo/Deferred", "dojo/when", "delite/Container"],
 		 * This can be the type of visual transitions involved. This might vary from one DisplayContainer to another.
 		 * @returns {Promise} A promise that will be resolved when the display & transition effect will have been
 		 * performed.
+		 * @fires module:delite/DisplayContainer.delite-before-show
+		 * @fires module:delite/DisplayContainer.delite-after-show
+		 * @fires module:delite/DisplayContainer.delite-display-load
 		 */
 		show: function (dest, params) {
 			// we need to warn potential app controller we are going to load a view & transition
@@ -48,28 +109,9 @@ define(["dcl/dcl", "dojo/Deferred", "dojo/when", "delite/Container"],
 				dcl.mix(event, params);
 				dcl.mix(event, value);
 
-				/**
-				 * Dispatched before child is shown.
-				 * @example
-				 * document.addEventListener("delite-before-show", function (evt) {
-				 *      console.log("about to show child", evt.child);
-				 * });
-				 * @event module:delite/DisplayContainer.delite-before-show
-				 * @property {Element} child - reference to child element
-				 */
 				self.emit("delite-before-show", event);
 
 				when(self.changeDisplay(value.child, event), function () {
-
-					/**
-					 * Dispatched after child is shown.
-					 * @example
-					 * document.addEventListener("delite-after-show", function (evt) {
-					 *      console.log("just displayed child", evt.child);
-					 * });
-					 * @event module:delite/DisplayContainer.delite-after-show
-					 * @property {Element} child - reference to child element
-					 */
 					self.emit("delite-after-show", event);
 
 					displayDeferred.resolve(value);
@@ -86,6 +128,9 @@ define(["dcl/dcl", "dojo/Deferred", "dojo/when", "delite/Container"],
 		 * This can be the type of visual transitions involved.  This might vary from one DisplayContainer to another.
 		 * @returns {Promise} A promise that will be resolved when the display & transition effect will have been
 		 * performed.
+		 * @fires module:delite/DisplayContainer.delite-display-load
+		 * @fires module:delite/DisplayContainer.delite-before-hide
+		 * @fires module:delite/DisplayContainer.delite-after-hide
 		 */
 		hide: function (dest, params) {
 			// we need to warn potential app controller we are going to load a view & transition
@@ -104,22 +149,6 @@ define(["dcl/dcl", "dojo/Deferred", "dojo/when", "delite/Container"],
 			// otherwise call the container load method
 			// note: emit() does not return the native event when it has been prevented but false value instead.
 
-			/**
-			 * Dispatched to let an application level listener create/load the child node.
-			 * @example
-			 * document.addEventListener("delite-display-load", function (evt) {
-			 *     // fetch the data for the specified id, then create a node with that data
-			 *     var def = evt.loadDeferred;
-			 *     fetchData(evt.dest).then(function(data) {
-			 *         var child = document.createElement("div");
-			 *         child.innerHTML = data;
-			 *         def.resolve({child: child});
-			 *     });
-			 *     evt.preventDefault();
-			 * });
-			 * @event module:delite/DisplayContainer.delite-display-load
-			 * @property {Promise} loadDeferred - promise to resolve with the child element
-			 */
 			var loadDeferred = this.emit("delite-display-load", event) ? this.load(dest) : event.loadDeferred;
 
 			when(loadDeferred, function (value) {
@@ -134,15 +163,6 @@ define(["dcl/dcl", "dojo/Deferred", "dojo/when", "delite/Container"],
 				dcl.mix(event, params);
 				dcl.mix(event, value);
 
-				/**
-				 * Dispatched before child is hidden.
-				 * @example
-				 * document.addEventListener("delite-before-hide", function (evt) {
-				 *      console.log("about to hide child", evt.child);
-				 * });
-				 * @event module:delite/DisplayContainer.delite-before-hide
-				 * @property {Element} child - reference to child element
-				 */
 				self.emit("delite-before-hide", event);
 
 				when(self.changeDisplay(value.child, event), function () {
@@ -151,15 +171,6 @@ define(["dcl/dcl", "dojo/Deferred", "dojo/when", "delite/Container"],
 						self.removeChild(value.child);
 					}
 
-					/**
-					 * Dispatched after child is hidden.
-					 * @example
-					 * document.addEventListener("delite-after-hide", function (evt) {
-					 *      console.log("just hid child", evt.child);
-					 * });
-					 * @event module:delite/DisplayContainer.delite-after-hide
-					 * @property {Element} child - reference to child element
-					 */
 					self.emit("delite-after-hide", event);
 
 					displayDeferred.resolve(value);

--- a/HasDropDown.js
+++ b/HasDropDown.js
@@ -12,6 +12,46 @@ define([
 	"dpointer/events"		// so can just monitor for "pointerdown"
 ], function (dcl, Deferred, domClass, when, keys, place, popup, Widget) {
 	/**
+	 * Dispatched before popup widget is shown.
+	 * @example
+	 * document.addEventListener("delite-before-show", function (evt) {
+	 *      console.log("about to show popup", evt.child);
+	 * });
+	 * @event module:delite/HasDropDown.delite-before-show
+	 * @property {Element} child - reference to popup
+	 */
+	
+	/**
+	 * Dispatched after popup widget is shown.
+	 * @example
+	 * document.addEventListener("delite-after-show", function (evt) {
+	 *      console.log("just displayed popup", evt.child);
+	 * });
+	 * @event module:delite/HasDropDown.delite-after-show
+	 * @property {Element} child - reference to popup
+	 */
+	
+	/**
+	 * Dispatched before popup widget is hidden.
+	 * @example
+	 * document.addEventListener("delite-before-hide", function (evt) {
+	 *      console.log("about to hide popup", evt.child);
+	 * });
+	 * @event module:delite/HasDropDown.delite-before-hide
+	 * @property {Element} child - reference to popup
+	 */
+	
+	/**
+	 * Dispatched after popup widget is hidden.
+	 * @example
+	 * document.addEventListener("delite-after-hide", function (evt) {
+	 *      console.log("just hid popup", evt.child);
+	 * });
+	 * @event module:delite/HasDropDown.delite-after-hide
+	 * @property {Element} child - reference to popup
+	 */
+
+	/**
 	 * Base class for widgets that need drop down ability.
 	 * @mixin module:delite/HasDropDown
 	 * @augments module:delite/Widget
@@ -392,25 +432,13 @@ define([
 		 *
 		 * @returns {Element|Promise} Element or Promise for the dropdown
 		 * @protected
+		 * @fires module:delite/DisplayContainer.delite-display-load
 		 */
 		loadDropDown: function () {
 			if (this.dropDown) {
 				return this.dropDown;
 			} else {
 				// tell app controller we are going to show the dropdown; it must return a pointer to the dropdown
-				/**
-				 * Dispatched if `HasDropDown#dropDown` is undefined, to let an application level listener create the
-				 * dropdown node.
-				 * @example
-				 * document.addEventListener("delite-display-load", function (evt) {
-				 *   if (evt.target.id === "dropdown_button_1") {
-				 *      evt.loadDeferred.resolve({child: new MyDropDown1({...})});
-				 *   }
-				 *   ...
-				 * }
-				 * @event module:delite/HasDropDown.delite-display-load
-				 * @property {Promise} loadDeferred - promise to resolve with the dropdown element
-				 */
 				var def = new Deferred();
 				this.emit("delite-display-load", {
 					loadDeferred: def
@@ -443,6 +471,8 @@ define([
 		 * user presses the down arrow button to open the drop down.
 		 * @returns {Promise} Promise for the drop down widget that fires when drop down is created and loaded.
 		 * @protected
+		 * @fires module:delite/HasDropDown.delite-before-show
+		 * @fires module:delite/HasDropDown.delite-after-show
 		 */
 		openDropDown: function () {
 			return this._openDropDownPromise ||
@@ -451,15 +481,6 @@ define([
 				var aroundNode = this.aroundNode || this,
 					self = this;
 
-				/**
-				 * Dispatched before popup widget is shown.
-				 * @example
-				 * document.addEventListener("delite-before-show", function (evt) {
-				 *      console.log("about to show popup", evt.child);
-				 * });
-				 * @event module:delite/HasDropDown.delite-before-show
-				 * @property {Element} child - reference to popup
-				 */
 				this.emit("delite-before-show", {
 					child: dropDown,
 					cancelable: false
@@ -519,15 +540,6 @@ define([
 					dropDown.setAttribute("aria-labelledby", this.id);
 				}
 
-				/**
-				 * Dispatched after popup widget is shown.
-				 * @example
-				 * document.addEventListener("delite-after-show", function (evt) {
-				 *      console.log("just displayed popup", evt.child);
-				 * });
-				 * @event module:delite/HasDropDown.delite-after-show
-				 * @property {Element} child - reference to popup
-				 */
 				this.emit("delite-after-show", {
 					child: dropDown,
 					cancelable: false
@@ -544,6 +556,8 @@ define([
 		 * Closes the drop down on this widget.
 		 * @param {boolean} focus - If true, refocus this widget.
 		 * @protected
+		 * @fires module:delite/HasDropDown.delite-before-hide
+		 * @fires module:delite/HasDropDown.delite-after-hide
 		 */
 		closeDropDown: function (focus) {
 			if (this._openDropDownPromise) {
@@ -564,15 +578,6 @@ define([
 					this.focus();
 				}
 
-				/**
-				 * Dispatched before popup widget is hidden.
-				 * @example
-				 * document.addEventListener("delite-before-hide", function (evt) {
-				 *      console.log("about to hide popup", evt.child);
-				 * });
-				 * @event module:delite/HasDropDown.delite-before-hide
-				 * @property {Element} child - reference to popup
-				 */
 				this.emit("delite-before-hide", {
 					child: this._currentDropDown,
 					cancelable: false
@@ -583,15 +588,6 @@ define([
 
 				this._currentDropDown.style.cssText = this._currentDropDown._originalStyle;
 
-				/**
-				 * Dispatched after popup widget is hidden.
-				 * @example
-				 * document.addEventListener("delite-after-hide", function (evt) {
-				 *      console.log("just hid popup", evt.child);
-				 * });
-				 * @event module:delite/HasDropDown.delite-after-hide
-				 * @property {Element} child - reference to popup
-				 */
 				this.emit("delite-after-hide", {
 					child: this._currentDropDown,
 					cancelable: false

--- a/KeyNav.js
+++ b/KeyNav.js
@@ -8,6 +8,18 @@ define([
 	"dpointer/events",		// so can just monitor for "pointerdown"
 	"./activationTracker"	// delite-deactivated event when focus removed from KeyNav and logical descendants
 ], function (dcl, domClass, keys, has, Widget) {
+	/**
+	 * Dispatched after the user has selected a different descendant, by clicking, arrow keys,
+	 * or keyboard search.
+	 * @example
+	 * widget.on("keynav-child-navigated", function (evt) {
+	 *	console.log("old value: " + evt.oldValue);
+	 *	console.log("new value: " + evt.newValue);
+	 * }
+	 * @event module:delite/KeyNav.keynav-child-navigated
+	 * @property {number} oldValue - The previously selected item.
+	 * @property {number} newValue - The new selected item.
+	 */
 
 	// Generate map from keyCode to handler name
 	var keycodeToMethod = {};
@@ -303,6 +315,7 @@ define([
 		 * code.  It marks that the specified child is the navigated one.
 		 * @param {Element} child
 		 * @private
+		 * @fires module:delite/KeyNav.keynav-child-navigated
 		 */
 		_descendantNavigateHandler: function (child) {
 			if (child && child !== this.navigatedDescendant) {
@@ -325,18 +338,6 @@ define([
 					domClass.remove(this.navigatedDescendant, "d-active-descendant");
 				}
 
-				/**
-				 * Dispatched after the user has selected a different descendant, by clicking, arrow keys,
-				 * or keyboard search.
-				 * @example
-				 * widget.on("keynav-child-navigated", function (evt) {
-				 *	console.log("old value: " + evt.oldValue);
-				 *	console.log("new value: " + evt.newValue);
-				 * }
-				 * @event module:delite/KeyNav.keynav-child-navigated
-				 * @property {number} oldValue - The previously selected item.
-				 * @property {number} newValue - The new selected item.
-				 */
 				this.emit("keynav-child-navigated", {
 					oldValue: this.navigatedDescendant,
 					newValue: child

--- a/Selection.js
+++ b/Selection.js
@@ -1,6 +1,21 @@
 /** @module delite/Selection */
 define(["dcl/dcl", "decor/sniff", "./Widget"], function (dcl, has, Widget) {
 	/**
+	 * Selection change event. Dispatched after the selection has
+	 * been modified through user interaction.
+	 * @example
+	 * widget.on("selection-change", function (evt) {
+	 *	console.log("old value: " + evt.oldValue);
+	 *	console.log("new value: " + evt.newValue);
+	 * }
+	 * @event module:delite/Selection.selection-change
+	 * @property {number} oldValue - The previously selected item.
+	 * @property {number} newValue- The new selected item.
+	 * @property {Object} renderer - The visual renderer of the selected/deselected item.
+	 * @property {Event} triggerEvent - The event that lead to the selection of the item.
+	 */
+	
+	/**
 	 * Mixin for widgets that manage a list of selected data items.
 	 * @mixin module:delite/Selection
 	 * @augments module:delite/Widget
@@ -256,22 +271,9 @@ define(["dcl/dcl", "decor/sniff", "./Widget"], function (dcl, has, Widget) {
 		 * @param {Object} renderer - The visual renderer of the selected/deselected item.
 		 * @param {Event} triggerEvent - The event that lead to the selection of the item.
 		 * @protected
+		 * @fires module:delite/Selection.selection-change
 		 */
 		dispatchSelectionChange: function (oldSelectedItem, newSelectedItem, renderer, triggerEvent) {
-			/**
-			 * Selection change event. Dispatched after the selection has
-			 * been modified through user interaction.
-			 * @example
-			 * widget.on("selection-change", function (evt) {
-			 *	console.log("old value: " + evt.oldValue);
-			 *	console.log("new value: " + evt.newValue);
-			 * }
-			 * @event module:delite/Selection.selection-change
-			 * @property {number} oldValue - The previously selected item.
-			 * @property {number} newValue- The new selected item.
-			 * @property {Object} renderer - The visual renderer of the selected/deselected item.
-			 * @property {Event} triggerEvent - The event that lead to the selection of the item.
-			 */
 			this.emit("selection-change", {
 				oldValue: oldSelectedItem,
 				newValue: newSelectedItem,


### PR DESCRIPTION
Purposes:
- Move @event to the beginning of module, in order to:
  - Stay closer with the way http://usejsdoc.org/tags-event.html specifies how to document events for AMD modules
  - Reduce the risk of declaring the same event more than once.
  - Have a systematic, consistent manner to declare events for events that are fired at one place or at multiple places.
  - Avoid using a jdsoc comment at a line of code which is not a declaration of a class member.
- Add @fires, which brings additional information into the doc.

See also https://github.com/ibm-js/jsdoc-amddcl/issues/41.

The section about events ("Declaring events") has been updated accordingly in 
https://docs.google.com/document/d/1fGBLuDAJRHFuSE4_NM2YfbRcCeYV40KWDXCuVyiSV_U/edit#heading=h.psrcktme7i7o
