### PR TITLE
FormValueWidget: fix handling of readOnly when inputNode distinct from valueNode (and small doc addition). Fixes #344

### DIFF
--- a/FormValueWidget.js
+++ b/FormValueWidget.js
@@ -67,11 +67,11 @@ define([
 			if ("readOnly" in oldValues) {
 				var isReadOnly = this.readOnly;
 				if (this.valueNode && this.valueNode !== this) {
-					this.valueNode.readOnly = isReadOnly; // inform screen reader
+					this.valueNode.readOnly = isReadOnly; // prevent value submission
 				}
 				if (this.inputNode !== this.valueNode && // avoid setting readOnly twice
 					this.inputNode && this.inputNode !== this) {
-					this.inputNode.readOnly = isReadOnly; // inform screen reader
+					this.inputNode.readOnly = isReadOnly; // prevent interaction
 				}
 				if (!isReadOnly) {
 					this.removeAttribute("readonly");

--- a/FormValueWidget.js
+++ b/FormValueWidget.js
@@ -54,8 +54,10 @@ define([
 	 */
 	return dcl(FormWidget, /** @lends module:delite/FormValueWidget# */{
 		/**
-		 * If true, this widget won't respond to user input.
-		 * Similar to `disabled` except `readOnly` form values are submitted.
+		 * If true, this widget won't respond to user input. Similar to `disabled` except
+		 * `readOnly` form values are submitted. FormValueWidget automatically updates
+		 * `valueNode`'s and `inputNode`'s `readOnly` property to match the widget's
+		 * `readOnly` property.
 		 * @member {boolean}
 		 * @default false
 		 */
@@ -66,6 +68,10 @@ define([
 				var isReadOnly = this.readOnly;
 				if (this.valueNode && this.valueNode !== this) {
 					this.valueNode.readOnly = isReadOnly; // inform screen reader
+				}
+				if (this.inputNode !== this.valueNode && // avoid setting readOnly twice
+					this.inputNode && this.inputNode !== this) {
+					this.inputNode.readOnly = isReadOnly; // inform screen reader
 				}
 				if (!isReadOnly) {
 					this.removeAttribute("readonly");

--- a/FormWidget.js
+++ b/FormWidget.js
@@ -58,6 +58,8 @@ define([
 
 		/**
 		 * If set to true, the widget will not respond to user input and will not be included in form submission.
+		 * FormWidget automatically updates `valueNode`'s and `inputNode`'s `disabled` property to match the widget's
+		 * `disabled` property.
 		 * @member {boolean}
 		 * @default false
 		 */
@@ -80,11 +82,26 @@ define([
 		 *
 		 * FormWidget updates `valueNode`'s `disabled` property to match the widget's disabled property.
 		 * FormValueWidget additionally updates `valueNodes`'s `value` and `readOnly` properties,
-		 * and `inputNode`'s `readOnly` property, to match the widget's equivalent properties.
+		 * to match the widget's equivalent properties.
 		 * Subclasses of FormWidget like checkboxes and radios should update `valueNode`'s `checked` property.
 		 *
 		 * @member {HTMLElement} module:delite/FormWidget#valueNode
 		 * @protected
+		 * @default undefined
+		 */
+		
+		/**
+		 * An element embedded within the widget, typically an `<input>`, used for end user
+		 * interaction. This property should be set only by widgets that use for end user interaction
+		 * a different element than `valueNode`.
+		 *
+		 * FormWidget updates `inputNode`'s `disabled` property to match the widget's disabled property.
+		 * FormValueWidget additionally updates `inputNodes`'s `readOnly` propertiy, to match the widget's
+		 * equivalent properties.
+		 *
+		 * @member {HTMLElement} module:delite/FormWidget#inputNode
+		 * @protected
+		 * @default undefined
 		 */
 
 		refreshRendering: function (oldValues) {
@@ -96,6 +113,10 @@ define([
 				var isDisabled = this.disabled;
 				if (this.valueNode && this.valueNode !== this) {
 					this.valueNode.disabled = isDisabled; // prevent submit
+				}
+				if (this.inputNode !== this.valueNode && // avoid setting disabled twice
+					this.inputNode && this.inputNode !== this) {
+					this.inputNode.disabled = isDisabled; // prevent interaction
 				}
 				tabStops.forEach(
 					function (nodeName) {

--- a/FormWidget.js
+++ b/FormWidget.js
@@ -79,8 +79,8 @@ define([
 		 * It is used to represent the widget's state/value during form submission.
 		 *
 		 * FormWidget updates `valueNode`'s `disabled` property to match the widget's disabled property.
-		 * FormValueWidget additionally updates `valueNodes`'s `value` and `readOnly` properties to match the
-		 * widget's equivalent properties.
+		 * FormValueWidget additionally updates `valueNodes`'s `value` and `readOnly` properties,
+		 * and `inputNode`'s `readOnly` property, to match the widget's equivalent properties.
 		 * Subclasses of FormWidget like checkboxes and radios should update `valueNode`'s `checked` property.
 		 *
 		 * @member {HTMLElement} module:delite/FormWidget#valueNode


### PR DESCRIPTION
See #344.