### PR TITLE
Viewport.getEffectiveBox(): fix for height computation on iOS8. Refs#348

### DIFF
--- a/Viewport.js
+++ b/Viewport.js
@@ -88,9 +88,9 @@ define([
 				}
 			}
 
-			// Account for space taken by auto-completion suggestions.
+			// Account for space taken by auto-correction suggestions.
 			if (has("ios") >= 8 &&
-				(!focusedNode.hasAttribute("autocorrect") || focusedNode.getAttribute("autocorrect") === "on") &&
+				(focusedNode.hasAttribute("autocorrect") || focusedNode.getAttribute("autocorrect") === "on") &&
 				/^(color|number|search|tel|text)$/.test(focusedNode.type)) {
 				box.h -= 40;
 			}


### PR DESCRIPTION
Fixes a tiny code error in Viewport.getEffectiveBox() affecting the height computation on iOS 8 and impacting delite/popup and delite/HasDropDown.

This is a partial fix for #348 - it improves the behavior on iOS 8 with virtual keyboard open, but even with this fix it remains suboptimal (but better than before).
