### PR TITLE
Implement attributeChangedCallback(), fixes #343.

### DIFF
--- a/CustomElement.js
+++ b/CustomElement.js
@@ -152,8 +152,15 @@ define([
 						attributes: true,
 						attributeOldValue: true
 					});
-				} else if (/* todo */ false) {
+				} else if (has("DOMAttrModified")) {
 					// see dir PR
+					this.addEventListener("DOMAttrModified", function (evt) {
+						if (evt.target === this) {
+							this.attributeChangedCallback(evt.attrName, evt.prevValue, evt.newValue);
+						}
+					});
+				} else {
+					throw new Error("can't monitor attributes");
 				}
 			}
 

--- a/CustomElement.js
+++ b/CustomElement.js
@@ -3,8 +3,9 @@ define([
 	"dcl/dcl",
 	"decor/Observable",
 	"decor/Destroyable",
-	"decor/Stateful"
-], function (dcl, Observable, Destroyable, Stateful) {
+	"decor/Stateful",
+	"delite/features"
+], function (dcl, Observable, Destroyable, Stateful, has) {
 
 	/**
 	 * Dispatched after the CustomElement has been attached.
@@ -133,12 +134,65 @@ define([
 		 * @fires module:delite/CustomElement#customelement-attached
 		 */
 		attachedCallback: dcl.after(function () {
+			// Call attributeChangedCallback() whenever an attribute value changes, unless it will be called
+			// automatically by the browser (currently chrome only?)
+			if (!has("document-register-element")) {
+				if ("MutationObserver" in window || "WebKitMutationObserver" in window) {
+					// If Polymer is loaded, use MutationObserver rather than WebKitMutationObserver
+					// to avoid error about "referencing a Node in a context where it does not exist".
+					var MO = window.MutationObserver || WebKitMutationObserver;	// for jshint
+					var observer = new MO(function (records) {
+						records.forEach(function (record) {
+							this.attributeChangedCallback(record.attributeName, record.oldValue,
+									this.getAttribute(record.attributeName));
+						}, this);
+					}.bind(this));
+					observer.observe(this, {
+						subtree: false,
+						attributes: true,
+						attributeOldValue: true
+					});
+				} else if (/* todo */ false) {
+					// see dir PR
+				}
+			}
+
 			this.attached = true;
 			this.emit("customelement-attached", {
 				bubbles: false,
 				cancelable: false
 			});
 		}),
+
+		/**
+		 * Called when an attribute's value is changed.
+		 *
+		 * This method is automatically chained, so subclasses generally do not need to use `dcl.superCall()`,
+		 * `dcl.advise()`, etc.
+		 * @param {string} attrName - Name of attribute.
+		 * @param {string} oldVal - Old value of attribute.
+		 * @param {string} newVal - New value of attribute.
+		 * @protected
+		 */
+		attributeChangedCallback: function (attrName, oldVal, newVal) {
+			// If this attribute has a corresponding property then notify that the property value changed.
+			// Note that it isn't checking for a custom setter.  Do we need support for that?
+			// TODO: make table better?  look in dojo/dom*.js
+			var attrToProp = {
+				"class": "className",
+				tabindex: "tabIndex"
+			};
+			var propName = attrToProp[attrName] || this._propCaseMap[attrName] || attrName;
+			if (propName in this) {
+				Observable.getNotifier(this).notify({
+					// Property is never new because setting up shadow property defines the property
+					type: "update",
+					object: this,
+					name: propName,
+					oldValue: oldVal
+				});
+			}
+		},
 
 		/**
 		 * Returns value for widget property based on attribute value in markup.
@@ -346,7 +400,8 @@ define([
 		// Override Stateful#observe() because the way to get the list of properties to watch is different
 		// than for a plain Stateful.  Especially since IE doesn't support prototype swizzling.
 		observe: function (callback) {
-			var propsToObserve = this._ctor._propsToObserve;
+			var propsToObserve = Object.create(this._ctor._propsToObserve);
+			propsToObserve.tabIndex = true;	// TODO: add all native properties reported by attributeChangedCallback()
 			var h = new Stateful.PropertyListObserver(this, propsToObserve);
 			h.open(callback, this);
 			return h;
@@ -378,6 +433,7 @@ define([
 	// destroy() is chained in Destroyable.js.
 	dcl.chainAfter(CustomElement, "createdCallback");
 	dcl.chainAfter(CustomElement, "attachedCallback");
+	dcl.chainAfter(CustomElement, "attributeChangedCallback");
 
 	return CustomElement;
 });

--- a/Widget.js
+++ b/Widget.js
@@ -102,26 +102,7 @@ define([
 					if (this.hasAttribute("tabindex")) { // initial value was specified
 						this.removeAttribute("tabindex");
 						desc.set.call(this, tabIndex); // call custom setter
-					}
-					var self = this;
-					// begin watching for changes to the tabindex DOM attribute
-					/* global WebKitMutationObserver */
-					if ("WebKitMutationObserver" in window) {
-						// If Polymer is loaded, use MutationObserver rather than WebKitMutationObserver
-						// to avoid error about "referencing a Node in a context where it does not exist".
-						var MO = window.MutationObserver || WebKitMutationObserver;	// for jshint
-						var observer = new MO(function () {
-							var newValue = self.getAttribute("tabindex");
-							if (newValue !== null) {
-								self.removeAttribute("tabindex");
-								desc.set.call(self, newValue);
-							}
-						});
-						observer.observe(this, {
-							subtree: false,
-							attributeFilter: ["tabindex"],
-							attributes: true
-						});
+						// TODO: change this to just notifyCurrentValue() ?
 					}
 					break;
 				}

--- a/features.js
+++ b/features.js
@@ -31,6 +31,18 @@ define(["requirejs-dplugins/has"], function (has) {
 		return !!node.attributes;
 	});
 
+	has.add("DOMAttrModified", function () {
+		var result = false;
+		function listener() {
+			result = true;
+		}
+		document.documentElement.addEventListener("DOMAttrModified", listener, false);
+		document.documentElement.setAttribute("checkAttrModified", true);
+		document.documentElement.removeAttribute("checkAttrModified");
+		document.documentElement.removeEventListener("DOMAttrModified", listener, false);
+		return result;
+	});
+
 	// Flag to enable support for textdir attribute
 	has.add("bidi", false);
 

--- a/tests/unit/CustomElement.js
+++ b/tests/unit/CustomElement.js
@@ -315,6 +315,9 @@ define([
 				accCalls = [];
 				w.setAttribute("foo", "bar");
 				setTimeout(def.rejectOnError(function () {
+					if (accCalls[0] && accCalls[0].oldVal === "") {
+						accCalls[0].oldVal = null;	// workaround inconsistent IE behavior
+					}
 					assert.deepEqual(accCalls, [{name: "foo", oldVal: null, newVal: "bar"}], "accCalls 1");
 
 					accCalls = [];
@@ -325,6 +328,9 @@ define([
 						accCalls = [];
 						w.removeAttribute("foo");
 						setTimeout(def.callback(function () {
+							if (accCalls[0] && accCalls[0].newVal === "") {
+								accCalls[0].newVal = null;	// workaround inconsistent IE behavior
+							}
 							assert.deepEqual(accCalls, [{name: "foo", oldVal: "bar2", newVal: null}], "accCalls 3");
 						}), 10);
 					}), 10);
@@ -344,8 +350,6 @@ define([
 
 				var def = this.async();
 
-				// TODO: I wanted to test refreshRendering() but Invalidating not mixed into CustomElement.
-				// So need tests in Widget too?
 				var changedProps = [];
 				w.observe(function (oldVals) {
 					changedProps.push(oldVals);
@@ -356,8 +360,16 @@ define([
 				w.tabIndex = 1;
 
 				setTimeout(def.callback(function () {
+					if (accCalls[0] && accCalls[0].oldVal === "") {
+						accCalls[0].oldVal = null;	// workaround inconsistent IE behavior
+					}
 					assert.deepEqual(accCalls, [{name: "tabindex", oldVal: null, newVal: "1"}],
 						"attributeChangedCallback");
+
+
+					if (changedProps[0] && changedProps[0].tabIndex === "") {
+						changedProps[0].tabIndex = null;	// workaround inconsistent IE behavior
+					}
 					assert.deepEqual(changedProps, [{tabIndex: null}], "observe()");
 
 					// TODO: change tabIndex again and check results
@@ -385,9 +397,19 @@ define([
 				w.setAttribute("tabindex", "1");
 
 				setTimeout(def.callback(function () {
+					if (accCalls[0] && accCalls[0].oldVal === "") {
+						accCalls[0].oldVal = null;	// workaround inconsistent IE behavior
+					}
 					assert.deepEqual(accCalls, [{name: "tabindex", oldVal: null, newVal: "1"}],
 						"attributeChangedCallback");
+
+
+					if (changedProps[0] && changedProps[0].tabIndex === "") {
+						changedProps[0].tabIndex = null;	// workaround inconsistent IE behavior
+					}
 					assert.deepEqual(changedProps, [{tabIndex: null}], "observe()");
+
+					// TODO: change tabIndex again and check results
 				}), 10);
 
 			}

--- a/tests/unit/CustomElement.js
+++ b/tests/unit/CustomElement.js
@@ -2,19 +2,27 @@ define([
 	"intern!object",
 	"intern/chai!assert",
 	"dcl/advise",
+	"decor/Stateful",
 	"delite/register",
 	"delite/CustomElement",
 	"requirejs-domready/domReady!"
-], function (registerSuite, assert, advise, register, CustomElement) {
+], function (registerSuite, assert, advise, Stateful, register, CustomElement) {
 
 	var container;
 	var calls = 0;
+	var MyCustomElement;
 
 	var obj = {
 		foo: function () {
 			// summary: empty function that we connect to
 		}
 	};
+
+	// track calls to attributeChangedCallback;
+	var accCalls = [];
+
+	// track calls to refreshRendering()
+	var rrCalls = [];
 
 	/*jshint multistr: true */
 	var html = "<test-ce-foo id='one' name='bob' attr1=10 attr2=10></test-ce-foo> \
@@ -254,29 +262,134 @@ define([
 			w.className = "foo";	// shouldn't cause notification as per CustomElement#_getProp()
 		},
 
-		"misc methods": {
-			"#findCustomElements": function () {
-				register("test-ce-foo", [HTMLElement, CustomElement], {
-					name: "",
-					attr1: 0,
-					attr2: 0
-				});
-				register("test-ce-bar", [HTMLElement, CustomElement], {
-					name: "",
-					attr1: 0,
-					attr2: 0
-				});
-				register("test-ce-baz", [HTMLElement, CustomElement], {
-					name: "",
-					attr1: 1,
-					attr2: 1
-				});
-				container.innerHTML = html;
-				register.parse(container);
+		"#findCustomElements": function () {
+			register("test-ce-foo", [HTMLElement, CustomElement], {
+				name: "",
+				attr1: 0,
+				attr2: 0
+			});
+			register("test-ce-bar", [HTMLElement, CustomElement], {
+				name: "",
+				attr1: 0,
+				attr2: 0
+			});
+			register("test-ce-baz", [HTMLElement, CustomElement], {
+				name: "",
+				attr1: 1,
+				attr2: 1
+			});
+			container.innerHTML = html;
+			register.parse(container);
 
-				assert.strictEqual(CustomElement.prototype.findCustomElements(container).length, 3);
-				assert.strictEqual(
-					CustomElement.prototype.findCustomElements(document.getElementById("threeWrapper")).length, 1);
+			assert.strictEqual(CustomElement.prototype.findCustomElements(container).length, 3);
+			assert.strictEqual(
+				CustomElement.prototype.findCustomElements(document.getElementById("threeWrapper")).length, 1);
+		},
+
+		"#attributeChangedCallback() etc.": {
+			setup: function () {
+				// TODO: need tabIndex in the prototype for Stateful#observe() to report changes
+				var MyMixin = register.dcl(null, {
+					// Mixin to workaround https://github.com/uhop/dcl/issues/9
+					//tabIndex: "0"
+				});
+				MyCustomElement = register("my-ce-attribute-changed", [HTMLElement, CustomElement, MyMixin], {
+					attributeChangedCallback: function (n, oldv, newv) {
+						accCalls.push({
+							name: n,
+							oldVal: oldv,
+							newVal: newv
+						});
+					}
+				});
+			},
+
+			"basic": function () {
+				var w = new MyCustomElement();
+				container.appendChild(w);
+				w.attachedCallback();
+
+				var def = this.async();
+
+				// Test setting attribute via setAttribute() calls attributeChangedCallback()
+				accCalls = [];
+				w.setAttribute("foo", "bar");
+				setTimeout(def.rejectOnError(function () {
+					assert.deepEqual(accCalls, [{name: "foo", oldVal: null, newVal: "bar"}], "accCalls 1");
+
+					accCalls = [];
+					w.setAttribute("foo", "bar2");
+					setTimeout(def.rejectOnError(function () {
+						assert.deepEqual(accCalls, [{name: "foo", oldVal: "bar", newVal: "bar2"}], "accCalls 2");
+
+						accCalls = [];
+						w.removeAttribute("foo");
+						setTimeout(def.callback(function () {
+							assert.deepEqual(accCalls, [{name: "foo", oldVal: "bar2", newVal: null}], "accCalls 3");
+						}), 10);
+					}), 10);
+				}), 10);
+			},
+
+			"setting mirror property": function () {
+				// Test that setting a mirror property like tabIndex calls both attributeChangedCallback()
+				// and also triggers Object.observe() callback.
+				// Test that attributeChangedCallback() called when attribute set indirectly via shadow property.
+				// TODO: deliver() doesn't make this synchronous but maybe I could make it synchronous if deliver()
+				// called MutationObserver.takeRecords().
+
+				var w = new MyCustomElement();
+				container.appendChild(w);
+				w.attachedCallback();
+
+				var def = this.async();
+
+				// TODO: I wanted to test refreshRendering() but Invalidating not mixed into CustomElement.
+				// So need tests in Widget too?
+				var changedProps = [];
+				w.observe(function (oldVals) {
+					changedProps.push(oldVals);
+				});
+
+				accCalls = [];
+
+				w.tabIndex = 1;
+
+				setTimeout(def.callback(function () {
+					assert.deepEqual(accCalls, [{name: "tabindex", oldVal: null, newVal: "1"}],
+						"attributeChangedCallback");
+					assert.deepEqual(changedProps, [{tabIndex: null}], "observe()");
+
+					// TODO: change tabIndex again and check results
+				}), 10);
+			},
+
+
+			// Test that setting the attribute via setAttribute() triggers refreshRendering()
+			"set attribute with shadow property": function () {
+				var w = new MyCustomElement();
+				container.appendChild(w);
+				w.attachedCallback();
+
+				var def = this.async();
+
+				// TODO: I wanted to test refreshRendering() but Invalidating not mixed into CustomElement.
+				// So need tests in Widget too?
+				var changedProps = [];
+				w.observe(function (oldVals) {
+					changedProps.push(oldVals);
+				});
+
+				accCalls = [];
+
+				w.setAttribute("tabindex", "1");
+
+				setTimeout(def.callback(function () {
+					assert.deepEqual(accCalls, [{name: "tabindex", oldVal: null, newVal: "1"}],
+						"attributeChangedCallback");
+					assert.deepEqual(changedProps, [{tabIndex: null}], "observe()");
+				}), 10);
+
 			}
 		}
 	});

--- a/tests/unit/Widget.js
+++ b/tests/unit/Widget.js
@@ -89,9 +89,9 @@ define([
 				});
 
 				var extended = new SpecialExtendedWidget({ });
-				extended.tabIndex = "5";
 				document.body.appendChild(extended);
 				extended.startup();
+				extended.tabIndex = "5";
 
 				var d = this.async(1000);
 


### PR DESCRIPTION
I read http://w3c.github.io/webcomponents/spec/custom/#dfn-enqueue-lifecycle-callback, but the spec is unclear to me.   What are the arguments to the attributeChangedCallback() method?   The spec mentions namespaces but isn't specific, so I followed Polymer's format of

```
attributeChanged: function(attrName, oldVal, newVal)
```

except that I called it attributeChangedCallback to match http://w3c.github.io/webcomponents/spec/custom/#dfn-enqueue-lifecycle-callback.

Some other minor points:

* Sync or async?   I did sync.
* When there's no old value or new value, should it pass null or undefined?  I did null.
* When should the method be called in relation to the attribute's value actually being changed?   I am calling it after the value has been changed since the method is called "...Changed", i.e. past tense.   The spec talks about element queues but it's quite confusing.