### PR TITLE
Adapt doc layout to fix the navigation of ibm-js.github.io

### DIFF
--- a/docs/BackgroundIframe.md
+++ b/docs/BackgroundIframe.md
@@ -1,5 +1,5 @@
 ---
-layout: default
+layout: doc
 title: delite/BackgroundIframe
 ---
 

--- a/docs/Container.md
+++ b/docs/Container.md
@@ -1,5 +1,5 @@
 ---
-layout: default
+layout: doc
 title: delite/Container
 ---
 

--- a/docs/CssState.md
+++ b/docs/CssState.md
@@ -1,5 +1,5 @@
 ---
-layout: default
+layout: doc
 title: delite/CssState
 ---
 

--- a/docs/CustomElement.md
+++ b/docs/CustomElement.md
@@ -1,5 +1,5 @@
 ---
-layout: default
+layout: doc
 title: delite/CustomElement
 ---
 

--- a/docs/DisplayContainer.md
+++ b/docs/DisplayContainer.md
@@ -1,5 +1,5 @@
 ---
-layout: default
+layout: doc
 title: delite/DisplayContainer
 ---
 

--- a/docs/FormValueWidget.md
+++ b/docs/FormValueWidget.md
@@ -1,5 +1,5 @@
 ---
-layout: default
+layout: doc
 title: delite/FormValueWidget
 ---
 

--- a/docs/FormWidget.md
+++ b/docs/FormWidget.md
@@ -1,5 +1,5 @@
 ---
-layout: default
+layout: doc
 title: delite/FormWidget
 ---
 

--- a/docs/HasDropDown.md
+++ b/docs/HasDropDown.md
@@ -1,5 +1,5 @@
 ---
-layout: default
+layout: doc
 title: delite/HasDropDown
 ---
 

--- a/docs/KeyNav.md
+++ b/docs/KeyNav.md
@@ -1,5 +1,5 @@
 ---
-layout: default
+layout: doc
 title: delite/KeyNav
 ---
 

--- a/docs/Scrollable.md
+++ b/docs/Scrollable.md
@@ -1,5 +1,5 @@
 ---
-layout: default
+layout: doc
 title: delite/Scrollable
 ---
 

--- a/docs/Selection.md
+++ b/docs/Selection.md
@@ -1,5 +1,5 @@
 ---
-layout: default
+layout: doc
 title: delite/Selection
 ---
 

--- a/docs/Store.md
+++ b/docs/Store.md
@@ -1,5 +1,5 @@
 ---
-layout: default
+layout: doc
 title: delite/Store
 ---
 

--- a/docs/StoreMap.md
+++ b/docs/StoreMap.md
@@ -1,5 +1,5 @@
 ---
-layout: default
+layout: doc
 title: delite/StoreMap
 ---
 

--- a/docs/Template.md
+++ b/docs/Template.md
@@ -1,5 +1,5 @@
 ---
-layout: default
+layout: doc
 title: delite/Template
 ---
 

--- a/docs/Viewport.md
+++ b/docs/Viewport.md
@@ -1,5 +1,5 @@
 ---
-layout: default
+layout: doc
 title: delite/ViewPort
 ---
 

--- a/docs/Widget.md
+++ b/docs/Widget.md
@@ -1,5 +1,5 @@
 ---
-layout: default
+layout: doc
 title: delite/Widget
 ---
 

--- a/docs/a11y.md
+++ b/docs/a11y.md
@@ -1,5 +1,5 @@
 ---
-layout: default
+layout: doc
 title: delite/a11y
 ---
 

--- a/docs/a11yclick.md
+++ b/docs/a11yclick.md
@@ -1,5 +1,5 @@
 ---
-layout: default
+layout: doc
 title: delite/a11yclick
 ---
 

--- a/docs/activationTracker.md
+++ b/docs/activationTracker.md
@@ -1,5 +1,5 @@
 ---
-layout: default
+layout: doc
 title: delite/activationTracker
 ---
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -1,5 +1,5 @@
 ---
-layout: default
+layout: doc
 title: Delite Architecture - Fast, Small, and Scalable
 ---
 

--- a/docs/customElements101.md
+++ b/docs/customElements101.md
@@ -1,5 +1,5 @@
 ---
-layout: default
+layout: doc
 title: Delite and Custom Elements
 ---
 

--- a/docs/defaultapp.md
+++ b/docs/defaultapp.md
@@ -1,5 +1,5 @@
 ---
-layout: default
+layout: doc
 title: defaultapp.css
 ---
 

--- a/docs/handlebars.md
+++ b/docs/handlebars.md
@@ -1,5 +1,5 @@
 ---
-layout: default
+layout: doc
 title: delite/handlebars
 ---
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,5 +1,5 @@
 ---
-layout: doc
+layout: docMain
 ---
 
 Delite provides a widget infrastructure that fits future standards but is possible

--- a/docs/migration.md
+++ b/docs/migration.md
@@ -1,5 +1,5 @@
 ---
-layout: default
+layout: doc
 title: delite/migration
 ---
 

--- a/docs/place.md
+++ b/docs/place.md
@@ -1,5 +1,5 @@
 ---
-layout: default
+layout: doc
 title: delite/place
 ---
 

--- a/docs/popup.md
+++ b/docs/popup.md
@@ -1,5 +1,5 @@
 ---
-layout: default
+layout: doc
 title: delite/popup
 ---
 

--- a/docs/register.md
+++ b/docs/register.md
@@ -1,5 +1,5 @@
 ---
-layout: default
+layout: doc
 title: delite/register
 ---
 

--- a/docs/setup.md
+++ b/docs/setup.md
@@ -1,5 +1,5 @@
 ---
-layout: default
+layout: doc
 title: setup
 ---
 

--- a/docs/theme.md
+++ b/docs/theme.md
@@ -1,5 +1,5 @@
 ---
-layout: default
+layout: doc
 title: delite/theme!
 ---
 

--- a/docs/themes.md
+++ b/docs/themes.md
@@ -1,5 +1,5 @@
 ---
-layout: default
+layout: doc
 title: delite/themes
 ---
 

--- a/docs/uacss.md
+++ b/docs/uacss.md
@@ -1,5 +1,5 @@
 ---
-layout: default
+layout: doc
 title: delite/uacss
 ---
 


### PR DESCRIPTION
This is to fix the menu of ibm-js.github.io.

If you navigate to http://ibm-js.github.io/delite/docs/master/customElements101.html you can see that the `Docs` item in the menu is not highlighted.