### PR TITLE
document delite and deliteful's i18n support

### DIFF
--- a/docs/g11n.md
+++ b/docs/g11n.md
@@ -3,7 +3,7 @@ layout: doc
 title: delite/nls
 ---
 
-# delite's natural language support
+# Internationalization and localization in delite
 
 ## Locale
 
@@ -52,7 +52,7 @@ The `textdir` property is useful in two cases:
 
 1. When the application boilerplate text is LTR, but the user data contained by the application
 is RTL (or vice-versa).  The typical case is that the application boilerplate text is in English, because it
-hasn't been translated, but the user data displayed by the application is Hebrew, Arabic, etc.
+hasn't been translated, but the user data displayed by the application is in an RTL language like Hebrew or Arabic.
 2. When the user data (that widgets display) is [bidirectional text](http://en.wikipedia.org/wiki/Bi-directional_text),
 for example a sentence in Hebrew that contains words in English.
 
@@ -82,7 +82,7 @@ Delite's API is currently optimized to support one of the two cases:
 In either case, delite will do the right thing simply by setting `<body dir=ltr>` or `<body dir=rtl>`.
 
 Delite also has limited support for displaying part of the page in RTL but other parts in LTR,
-by directly setting the `dir` and  of individual widgets, but the application should obey the following rules:
+by directly setting the `dir` and `textdir` of individual widgets, but the application should obey the following rules:
 
 * Applications should not set `dir=ltr` or `dir=rtl` except on `<html>` or `<body>`, and on individual widgets.
 * Applications should not change the `dir` setting on `<html>` or `<body>` after widgets have been instantiated.

--- a/docs/g11n.md
+++ b/docs/g11n.md
@@ -17,8 +17,8 @@ This is because messages are loaded via the i18n! plugin, which uses the locale 
 
 ## RTL and BIDI support
 
-Delite and dependent projects like deliteful support widgets rendered in either LTR or RTL.
-Support encompasses features like:
+Delite and dependent projects like deliteful support can render widgets in either LTR or RTL.
+Support for RTL encompasses features like:
 
 * GUI layout (ex: whether a Combobox's arrow is to the left or right of the `<input>` area)
 * Keyboard control: make sure that the left and right arrow keys move to the left and right (respectively) even when
@@ -27,7 +27,7 @@ the page is in RTL mode.
 
 ### has("bidi") flag
 
-If an application will (or may be) run in RTL locales, it should define the `has("bidi")` flag as follows:
+If an application will be (or may be) run in RTL locales, it should define the `has("bidi")` flag as follows:
 
 ```js
 requirejs.config({
@@ -42,7 +42,7 @@ requirejs.config({
 ```
 
 The `has("bidi")` flag enables advanced bidi features such as the `textdir` property.
-In addition, for some widgets, it's necessary to turn on `has("bidi")` to get basic RTL features
+In addition, for some widgets, `has("bidi")` is necessary to turn on basic RTL features
 such as correct keyboard handling and proper GUI layout.
 
 
@@ -74,7 +74,7 @@ Unlike `dir`, `textdir` will not be inherited from a setting on `<html>` or `<bo
 
 For reasons of performance and practicality, delite has certain restrictions on its RTL and bidi support.
 
-Delite's API is currently optimized to support one of the two cases:
+Delite's API is currently optimized to support the following cases:
 
 1. application GUI layout and user data is LTR text
 2. application GUI layout and user data is RTL text
@@ -82,7 +82,9 @@ Delite's API is currently optimized to support one of the two cases:
 In either case, delite will do the right thing simply by setting `<body dir=ltr>` or `<body dir=rtl>`.
 
 Delite also has limited support for displaying part of the page in RTL but other parts in LTR,
-by directly setting the `dir` and `textdir` of individual widgets, but the application should obey the following rules:
+by directly setting the `dir` and `textdir` of individual widgets.
+
+In any case, the application should obey the following rules:
 
 * Applications should not set `dir=ltr` or `dir=rtl` except on `<html>` or `<body>`, and on individual widgets.
 * Applications should not change the `dir` setting on `<html>` or `<body>` after widgets have been instantiated.
@@ -92,3 +94,15 @@ widgets too.
 
 Breaking any of these rules will lead to undefined behavior.  Often it will lead to widgets being in a half-way
 state where, for example, the layout becomes RTL but the keyboard support is still in LTR mode.
+
+
+## Writing widgets
+
+Ibm-js provides two modules that can be used to build widgets with internationalization support:
+
+* [`requirejs-dplugins/i18n`](/requirejs-dplugins/docs/0.5.0/i18n.html) - A plugin to load
+* [`ecma402`](https://github.com/ibm-js/ecma402/blob/master/README.md) - an implementation of the
+[ECMA-402 JavaScript Internationalization APIs standard](http://www.ecma-international.org/ecma-402/1.0/ECMA-402.pdf)
+for number formatting ( Intl.NumberFormat ) and date and time formatting ( Intl.DateTimeFormat ).
+
+Please see those respective pages for details.

--- a/docs/index.md
+++ b/docs/index.md
@@ -27,6 +27,7 @@ Specifically, it's based on the following concepts:
 * [Migration notes for dijit based applications](migration.md)
 * [Notes on theme generation](themes.md)
 * [How to load delite modules](setup.md)
+* [NLS support](nls.md)
 
 ## Utility modules
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -27,7 +27,7 @@ Specifically, it's based on the following concepts:
 * [Migration notes for dijit based applications](migration.md)
 * [Notes on theme generation](themes.md)
 * [How to load delite modules](setup.md)
-* [NLS support](nls.md)
+* [Internationalization and localization](g11n.md)
 
 ## Utility modules
 

--- a/docs/nls.md
+++ b/docs/nls.md
@@ -1,0 +1,94 @@
+---
+layout: doc
+title: delite/nls
+---
+
+# delite's natural language support
+
+## Locale
+
+Delite supports a locale setting for the page.
+This affects the language of boilerplate text in widgets as well as localizations
+such as how numbers and dates are displayed.
+The setting is based on the browser's locale, and affects all widgets on the page.
+
+Note that the HTML `lang` attribute set on individual elements is ignored.
+This is because messages are loaded via the i18n! plugin, which uses the locale of the page.
+
+## RTL and BIDI support
+
+Delite and dependent projects like deliteful support widgets rendered in either LTR or RTL.
+Support encompasses features like:
+
+* GUI layout (ex: whether a Combobox's arrow is to the left or right of the `<input>` area)
+* Keyboard control: make sure that the left and right arrow keys move to the left and right (respectively) even when
+the page is in RTL mode.
+* `textdir` property used to control widget text direction independently of GUI direction.  See below for details.
+
+### has("bidi") flag
+
+If an application will (or may be) run in RTL locales, it should define the `has("bidi")` flag as follows:
+
+```js
+requirejs.config({
+	...
+	config: {
+		...
+		"requirejs-dplugins/has": {
+			bidi: true
+		}
+	}
+});
+```
+
+The `has("bidi")` flag enables advanced bidi features such as the `textdir` property.
+In addition, for some widgets, it's necessary to turn on `has("bidi")` to get basic RTL features
+such as correct keyboard handling and proper GUI layout.
+
+
+### Textdir
+
+The `textdir` property is useful in two cases:
+
+1. When the application boilerplate text is LTR, but the user data contained by the application
+is RTL (or vice-versa).  The typical case is that the application boilerplate text is in English, because it
+hasn't been translated, but the user data displayed by the application is Hebrew, Arabic, etc.
+2. When the user data (that widgets display) is [bidirectional text](http://en.wikipedia.org/wiki/Bi-directional_text),
+for example a sentence in Hebrew that contains words in English.
+
+In either case, `textdir` declares the "natural text direction", i.e. whether the text should be written
+right-to-left or left-to-right.  For example, in the text "Hello אר!", "Hello" should appear on the left, but in
+the text "!Bob שלום", the Hebrew word for "hello" appears on the right.
+
+The allowed values are:
+
+1. "ltr"
+2. "rtl"
+3. "auto" - contextual - the direction of a text defined by first strong letter (see
+http://en.wikipedia.org/wiki/Bi-directional_text for an explanation of strong characters vs. weak characters)
+
+Note that the `textdir` property must be set directly on each widget.
+Unlike `dir`, `textdir` will not be inherited from a setting on `<html>` or `<body>`.
+
+### Limitations of RTL support
+
+For reasons of performance and practicality, delite has certain restrictions on its RTL and bidi support.
+
+Delite's API is currently optimized to support one of the two cases:
+
+1. application GUI layout and user data is LTR text
+2. application GUI layout and user data is RTL text
+
+In either case, delite will do the right thing simply by setting `<body dir=ltr>` or `<body dir=rtl>`.
+
+Delite also has limited support for displaying part of the page in RTL but other parts in LTR,
+by directly setting the `dir` and  of individual widgets, but the application should obey the following rules:
+
+* Applications should not set `dir=ltr` or `dir=rtl` except on `<html>` or `<body>`, and on individual widgets.
+* Applications should not change the `dir` setting on `<html>` or `<body>` after widgets have been instantiated.
+* Applications should not set `dir=auto` on any widget, nor on any ancestor node.
+* If the application sets the `dir` property of any widget or node, then it must explicitly set `dir` on all descendant
+widgets too.
+
+Breaking any of these rules will lead to undefined behavior.  Often it will lead to widgets being in a half-way
+state where, for example, the layout becomes RTL but the keyboard support is still in LTR mode.


### PR DESCRIPTION
Here's my attempt to document delite and deliteful's i18n support, in particular that part about the current restrictions of what isn't supported, as I promised to do in a meeting with @cjolif and @pruzand.   The document isn't really specific to delite but I didn't know a better place to put it.

Please review and let me know corrections for any mistakes, or terminology, including the title itself (should it be "internationalisation support"?).

There are a few possible future enhancements for delite, but for now I'm just documenting the **current** state.   For the record, known possible future enhancements/changes are:

* since an app can set `dir` on `<html>` or `<body>`, shouldn't it be able to set `textdir` too?
* @semion1956 is working on a PR to enable inheriting `dir` from ancestor nodes other than `<html>` or `<body>`.   Related to that, if `dir` can be inherited from any ancestor node, then what about `textdir`?
* splitting `has("bidi")` into two separate flags, one for "advanced features" (whatever that means) and one for "basic features".   also, possibly renaming `has("bidi")`. (ibm-js/deliteful#462)

After this doc is committed, the PR's for future enhancements should update this document.

PS: @clmath, AFAICT the documentation for i18n! doesn't state how it determines the browser's locale.  I'm guessing it's from the metadata passed over HTTP (requested languages or whatever it's called), but maybe it's from looking at the `lang` attribute on `<html>` or `<body>`?   Let me know the algorithm so I can document it here.