### PR TITLE
remove unused dcl in Bidi.js

### DIFF
--- a/Bidi.js
+++ b/Bidi.js
@@ -4,9 +4,8 @@
  * @module delite/Bidi
  */
 define([
-	"dcl/dcl",
 	"./features"
-], function (dcl, has) {
+], function (has) {
 
 	// UCC - constants that will be used by bidi support.
 	var LRE = "\u202A",


### PR DESCRIPTION
I noticed that dcl was declared but unused in Bidi.js.

It was probably due by this commit :
https://github.com/ibm-js/delite/commit/fbcff47f42c53911a46248b45f45c1a868df4ec8