### PR TITLE
tutorial link updated to index.html

### DIFF
--- a/_layouts/main.html
+++ b/_layouts/main.html
@@ -41,7 +41,7 @@
 		<div class="navbar-collapse collapse">
 			<ul class="nav navbar-nav">
 				<li id="getting-started"><a href="{{site.baseurl}}/getting-started.html">Getting Started</a></li>
-				<li id="tutorial"><a href="{{site.baseurl}}/docs/0.6.0/tutorial/beginner.html">Tutorial</a></li>
+				<li id="tutorial"><a href="{{site.baseurl}}/docs/0.6.0/tutorial/index.html">Tutorial</a></li>
 				<li id="docs"><a href="{{site.baseurl}}/docs/0.6.0/index.html">Docs</a></li>
 				<!--<li><a href="#Showcase">Demos</a></li>-->
 				<li id="community"><a href="{{site.baseurl}}/community.html">Community</a></li>


### PR DESCRIPTION
Along with https://github.com/ibm-js/delite/pull/399 and the branch updates to https://github.com/ibm-js/delite-tutorial this should be pulled so that the tutorial now links to http://ibm-js.github.io/delite/docs/0.6.0/tutorial/index.html