### PR TITLE
Polyfill <template> (i.e. move child nodes to content property).

### DIFF
--- a/features.js
+++ b/features.js
@@ -75,6 +75,10 @@ define(["requirejs-dplugins/has"], function (has) {
 			/* jshint proto: false */
 			return !!node.attributes;
 		});
+
+		// Support for <template> elements (specifically, that their content is available via templateNode.content
+		// rather than templateNode.children[] etc.
+		has.add("dom-template", !!document.createElement("template").content);
 	}
 
 	return has;

--- a/register.js
+++ b/register.js
@@ -540,7 +540,24 @@ define([
 
 	// Setup initial parse of document and also listeners for future document modifications.
 	if (!has("document-register-element") && doc) {
-		domReady(deliver);
+		domReady(function () {
+			if (!has("dom-template")) {
+				// Move <template> child nodes to .content property, so that we don't parse custom elements in
+				// <template> nodes.  Could be done on dynamically created nodes too, but currently there's no need.
+				var template, idx = 0, nodes = doc.querySelectorAll("template");
+				while ((template = nodes[idx++])) {
+					if (!template.content) {
+						var child, content = template.content = doc.createDocumentFragment();
+						while ((child = template.firstChild)) {
+							content.appendChild(child);
+						}
+					}
+				}
+			}
+
+			// Upgrade all custom element nodes, and setup listeners for future changes.
+			deliver();
+		});
 	}
 
 	// Setup return value as register() method, with other methods hung off it.

--- a/tests/functional/all.js
+++ b/tests/functional/all.js
@@ -8,5 +8,6 @@ define([
 	"./KeyNav",
 	"./polymer",
 	"./popup",
+	"./register",
 	"./DojoParser"
 ]);

--- a/tests/functional/register.html
+++ b/tests/functional/register.html
@@ -1,0 +1,37 @@
+<!DOCTYPE html>
+<html>
+<head>
+	<script src="../../../requirejs/require.js"></script>
+	<script>
+		var ready = false; // set to true when the test page is ready
+		require.config({
+			baseUrl: "../../.."
+		});
+		require(["delite/register", "requirejs-domready/domReady!"], function (register) {
+			register("test-widget", [HTMLElement], {
+				_createdCallbackCalled: false,
+				createdCallback: function () {
+					this._createdCallbackCalled = true;
+				},
+
+				_attachedCallbackCalled: false,
+				attachedCallback: function () {
+					this._attachedCallbackCalled = true;
+				}
+			});
+
+			// Set global variable to signal that the test page is ready.
+			// Give register time to instantiate widgets before setting flag.
+			setTimeout(function () {
+				ready = true;
+			}, 0);
+		});
+	</script>
+</head>
+<body>
+	<template>
+		<test-widget id="inside"></test-widget>
+	</template>
+	<test-widget id="outside"></test-widget>
+</body>
+</html>

--- a/tests/functional/register.js
+++ b/tests/functional/register.js
@@ -1,0 +1,48 @@
+define([
+	"require",
+	"intern",
+	"intern!object",
+	"intern/chai!assert",
+	"intern/dojo/node!leadfoot/helpers/pollUntil"
+], function (require, intern, registerSuite, assert, pollUntil) {
+
+	registerSuite({
+		name: "register functional tests",
+
+		"setup": function () {
+			return this.remote
+				.get(require.toUrl("./register.html"))
+				.then(pollUntil("return ready || null;", [],
+					intern.config.WAIT_TIMEOUT, intern.config.POLL_INTERVAL));
+		},
+
+		"custom element created": function () {
+			return this.remote
+				.execute("return document.getElementById('outside')._createdCallbackCalled").then(function (value) {
+					assert(value, "custom element created");
+				})
+				.execute("return document.getElementById('outside')._attachedCallbackCalled").then(function (value) {
+					assert(value, "custom element attached");
+				});
+
+		},
+		
+		"template": function () {
+			return this.remote
+				.execute("var children = document.querySelector('template').children; " +
+					"return children ? children.length : 0;").then(function (value) {
+					assert.strictEqual(value, 0, "<template> children removed (if they existed in the first place)");
+				})
+				.execute("return document.querySelector('template').content.querySelector('*').tagName").then(
+						function (value) {
+					assert.strictEqual(value.toLowerCase(), "test-widget", "children moved to .content property");
+				})
+				.execute(
+					"return '_createdCallbackCalled' in document.querySelector('template').content.querySelector('*')")
+					.then(function (value) {
+					assert.isFalse(value, "custom element in template not upgraded");
+				});
+		}
+
+	});
+});


### PR DESCRIPTION
Avoids accidentally instantiating custom elements inside templates.

Fixes #408.

CC @asudoh.  I didn't try liaison w/this patch.  It's possible that there are other issues with liaison that need to be fixed too before it works with delite 0.7.