### PR TITLE
DisplayContainer: Extracting method for loading a child

### DIFF
--- a/docs/DisplayContainer.md
+++ b/docs/DisplayContainer.md
@@ -36,7 +36,7 @@ mycontainer.show("mychildid", {/* optional params depending on the subclass */})
 ## Extending DisplayContainer
 
 In order for a container to leverage `delite/DisplayContainer` it must extend it and possibly implement the `changeDisplay()` 
-and/or `load()` functions in order to customize their behavior. The following subclass is looking at the parameters passed
+and/or `loadChild()` functions in order to customize their behavior. The following subclass is looking at the parameters passed
 to the `show()` or `hide()` function in order to perform a visual transition when switching the child visibility. In 
 particular it performs a fading in or out transition based on the value of the `fade` parameter.
 


### PR DESCRIPTION
The `show()` and `hide()` methods load a child before show it or hide it, but sometimes the widget could want only to load a child dynamically, either by using a controller to load it or using its own `load()` method.

In this PR I take the common code used on the `show()` and `hide()` methods related to loading a child and I extract it to a new method -> `loadChild()` 
(This name has to be discussed in order to avoid confusion between this method and the `load()` method)