### PR TITLE
Widget: allow template to be set dynamically

### DIFF
--- a/Container.js
+++ b/Container.js
@@ -51,8 +51,9 @@ define([
 			before: function () {
 				// Save original markup to put into this.containerNode.
 				var srcDom = this._srcDom = this.ownerDocument.createDocumentFragment();
-				while (this.firstChild) {
-					srcDom.appendChild(this.firstChild);
+				var oldContainer = this.containerNode || this;
+				while (oldContainer.firstChild) {
+					srcDom.appendChild(oldContainer.firstChild);
 				}
 			},
 
@@ -70,7 +71,7 @@ define([
 
 		appendChild: dcl.superCall(function (sup) {
 			return function (child) {
-				if (this.created) {
+				if (this.rendered) {
 					var res = sup.call(this.containerNode, child);
 					this.onAddChild(child);
 					return res;
@@ -82,7 +83,7 @@ define([
 
 		insertBefore: dcl.superCall(function (sup) {
 			return function (newChild, refChild) {
-				if (this.created) {
+				if (this.rendered) {
 					var res = sup.call(this.containerNode, newChild, refChild);
 					this.onAddChild(newChild);
 					return res;

--- a/CssState.js
+++ b/CssState.js
@@ -29,14 +29,6 @@ define([
 		 */
 		booleanCssProps: ["disabled", "readOnly", "selected", "opened"],
 
-		postRender: function () {
-			["checked", "state"].concat(this.booleanCssProps).forEach(function (name) {
-				if (this[name]) {
-					this.notifyCurrentValue(name);
-				}
-			});
-		},
-
 		refreshRendering: function (oldVals) {
 			// Monitoring changes to disabled, readonly, etc. state, and update CSS class of root node
 			this.booleanCssProps.forEach(function (name) {

--- a/CustomElement.js
+++ b/CustomElement.js
@@ -228,18 +228,22 @@ define([
 		 * @method
 		 * @fires module:delite/CustomElement#customelement-attached
 		 */
-		attachedCallback: dcl.after(function () {
-			// Call computeProperties() and refreshRendering() for declaratively set properties.
-			// Do this in attachedCallback() rather than createdCallback() to avoid calling refreshRendering() etc.
-			// prematurely in the programmatic case (i.e. calling it before user parameters have been applied).
-			this.deliver();
+		attachedCallback: dcl.advise({
+			before: function () {
+				// Call computeProperties() and refreshRendering() for declaratively set properties.
+				// Do this in attachedCallback() rather than createdCallback() to avoid calling refreshRendering() etc.
+				// prematurely in the programmatic case (i.e. calling it before user parameters have been applied).
+				this.deliver();
+			},
 
-			this.attached = true;
+			after: function () {
+				this.attached = true;
 
-			this.emit("customelement-attached", {
-				bubbles: false,
-				cancelable: false
-			});
+				this.emit("customelement-attached", {
+					bubbles: false,
+					cancelable: false
+				});
+			}
 		}),
 
 		/**

--- a/Dialog.js
+++ b/Dialog.js
@@ -10,7 +10,7 @@ define([
 	 * @augments module:delite/Widget
 	 */
 	return dcl(Widget, /** @lends module:delite/Dialog# */ {
-		postRender: function () {
+		createdCallback: function () {
 			this.on("keydown", this._dialogKeyDownHandler.bind(this));
 		},
 

--- a/DialogUnderlay.js
+++ b/DialogUnderlay.js
@@ -22,9 +22,7 @@ define([
 	var DialogUnderlay = register("d-dialog-underlay", [HTMLElement, Widget],
 			/** @lends module:delite/DialogUnderlay# */ {
 
-		render: function () {
-			this.className = "d-dialog-underlay";
-		},
+		baseClass: "d-dialog-underlay",
 
 		createdCallback: register.after(function () {
 			// Automatically append the underlay to <body> on creation.

--- a/FormValueWidget.js
+++ b/FormValueWidget.js
@@ -89,7 +89,7 @@ define([
 			}
 		},
 
-		postRender: function () {
+		createdCallback: function () {
 			this.on("delite-activated", function () {
 				// Called when user may be about to start input.
 				// Saves the widget's current value, which is the most recent of:

--- a/FormWidget.js
+++ b/FormWidget.js
@@ -83,10 +83,6 @@ define([
 		 * @protected
 		 */
 
-		postRender: function () {
-			this.notifyCurrentValue("tabStops");
-		},
-
 		/**
 		 * A form element, typically an `<input>`, embedded within the widget, and likely hidden.
 		 * It is used to represent the widget's state/value during form submission.
@@ -250,7 +246,7 @@ define([
 			};
 		}),
 
-		createdCallback: function () {
+		postRender: function () {
 			// Move all initially specified aria- attributes to focus node(s).
 			var attr, idx = 0;
 			while ((attr = this.attributes[idx++])) {

--- a/HasDropDown.js
+++ b/HasDropDown.js
@@ -273,8 +273,6 @@ define([
 		},
 
 		createdCallback: function () {
-			this.setAttribute("aria-haspopup", "true");
-
 			// set this.hovering when mouse is over widget so we can differentiate real mouse clicks from synthetic
 			// mouse clicks generated from JAWS upon keyboard events
 			this.on("pointerenter", function () {
@@ -298,6 +296,8 @@ define([
 		},
 
 		postRender: function () {
+			this.setAttribute("aria-haspopup", "true");
+
 			this.buttonNode = this.buttonNode || this.focusNode || this;
 			this.popupStateNode = this.popupStateNode || this.focusNode || this.buttonNode;
 

--- a/KeyNav.js
+++ b/KeyNav.js
@@ -131,19 +131,7 @@ define([
 			return this;
 		},
 
-		postRender: function () {
-			// Setup function to check which child nodes are navigable.
-			if (typeof this.descendantSelector === "string") {
-				var matchesFuncName = has("dom-matches");
-				this._selectorFunc = function (elem) {
-					return elem[matchesFuncName](this.descendantSelector);
-				};
-			} else if (this.descendantSelector) {
-				this._selectorFunc = this.descendantSelector;
-			} else {
-				this._selectorFunc = function (elem) { return elem.parentNode === this.containerNode; };
-			}
-
+		createdCallback: function () {
 			this.on("keypress", this._keynavKeyPressHandler.bind(this));
 			this.on("keydown", this._keynavKeyDownHandler.bind(this));
 			this.on("click", function (evt) {
@@ -169,6 +157,18 @@ define([
 					}
 				}
 			}.bind(this));
+
+			// Setup function to check which child nodes are navigable.
+			if (typeof this.descendantSelector === "string") {
+				var matchesFuncName = has("dom-matches");
+				this._selectorFunc = function (elem) {
+					return elem[matchesFuncName](this.descendantSelector);
+				};
+			} else if (this.descendantSelector) {
+				this._selectorFunc = this.descendantSelector;
+			} else {
+				this._selectorFunc = function (elem) { return elem.parentNode === this.containerNode; };
+			}
 		},
 
 		attachedCallback: function () {

--- a/Scrollable.js
+++ b/Scrollable.js
@@ -71,10 +71,6 @@ define([
 		 */
 		scrollableNode: null,
 
-		postRender: function () {
-			this.notifyCurrentValue("scrollDirection");
-		},
-
 		render: dcl.after(function () {
 			// Do it using after advice to give a chance to a custom widget to
 			// set the scrollableNode at latest in an overridden render().
@@ -90,8 +86,8 @@ define([
 				.on("selectstart", false);
 		}),
 
-		refreshRendering: function (props) {
-			if (props.scrollDirection) {
+		refreshRendering: function (oldVals) {
+			if ("scrollDirection" in oldVals) {
 				$(this.scrollableNode)
 					.toggleClass("d-scrollable", this.scrollDirection !== "none")
 					.toggleClass("d-scrollable-h", /^(both|horizontal)$/.test(this.scrollDirection))

--- a/Selection.js
+++ b/Selection.js
@@ -22,7 +22,7 @@ define(["dcl/dcl", "decor/sniff", "./Widget"], function (dcl, has, Widget) {
 	 * @augments module:delite/Widget
 	 */
 	return dcl(Widget, /** @lends module:delite/Selection# */{
-		preRender: function () {
+		createdCallback: function () {
 			this._set("selectedItems", []);
 		},
 		

--- a/Store.js
+++ b/Store.js
@@ -148,7 +148,7 @@ define([
 		 */
 		computeProperties: function (props, isAfterCreation) {
 			// If this call is upon widget creation but `this.store` is not available, don't bother querying store
-			if (("source" in props || "query" in props) && (this.store || !isAfterCreation)) {
+			if (("source" in props || "query" in props) && (this.source || !isAfterCreation)) {
 				this.queryStoreAndInitItems(this.processQueryResult);
 			}
 		},

--- a/Store.js
+++ b/Store.js
@@ -87,22 +87,20 @@ define([
 			return item;
 		},
 
-		preRender: function () {
-			// Get the data from the textContent and clear it
-			if (this.source === null && this.textContent !== "") {
-				this._saveData(this.textContent);
-				this.textContent = "";
-			}
-		},
-
-		attachedCallback: function () {
-			// Setting the source with the data got from the textContent (not done in preRender because the source
-			// is not send in the props list when it is modified there)
-			if (this._source) {
-				this.source = new ObservableArray();
-				for (var j = 0; j < this._source.length; j++) {
-					this.source[j] = new Observable(this._source[j]);
+		createdCallback: function () {
+			// Get the data from the textContent
+			if (this.textContent.trim()) {
+				var data = JSON.parse("[" + this.textContent + "]");
+				if (data.length) {
+					this.source = new ObservableArray();
+					for (var j = 0; j < data.length; j++) {
+						if (!data[j].id) {
+							data[j].id = Math.random();
+						}
+						this.source[j] = new Observable(data[j]);
+					}
 				}
+				this.textContent = "";
 			}
 		},
 
@@ -111,15 +109,6 @@ define([
 		 * @param text
 		 */
 		_saveData: function (text) {
-			var data = JSON.parse("[" + text + "]");
-			for (var j = 0; j < data.length; j++) {
-				if (!data[j].id) {
-					data[j].id = Math.random();
-				}
-			}
-			if (data.length !== 0) {
-				this._source = data;
-			}
 		},
 
 		/**

--- a/Store.js
+++ b/Store.js
@@ -143,10 +143,12 @@ define([
 		 * If the store parameters are invalidated, queries the store, creates the render items and calls initItems() 
 		 * when ready. If an error occurs a 'query-error' event will be fired.
 		 * @param props
+		 * @param isAfterCreation
 		 * @protected
 		 */
-		computeProperties: function (props) {
-			if ("source" in props || "query" in props) {
+		computeProperties: function (props, isAfterCreation) {
+			// If this call is upon widget creation but `this.store` is not available, don't bother querying store
+			if (("source" in props || "query" in props) && (this.store || !isAfterCreation)) {
 				this.queryStoreAndInitItems(this.processQueryResult);
 			}
 		},

--- a/Widget.js
+++ b/Widget.js
@@ -72,10 +72,17 @@ define([
 		//////////// INITIALIZATION METHODS ///////////////////////////////////////
 
 		createdCallback: function () {
-			this.preRender();
-			this.render();
-			this.postRender();
+			this.widgetId = ++cnt;
 		},
+
+		// deliver() is called on widget creation, either from CustomElement#attachedCallback() (for the declarative
+		// case) or the widget constructor (for the programmatic case).  At that point, Invalidating's observers haven't
+		// been set up yet, so Stateful#deliver() won't call computeProperties() or refreshRendering().  But instead,
+		// Widget calls Invalidating#initializeInvalidating(), which calls computeProperties(this) and
+		// refreshRendering(this).
+		deliver: dcl.after(function () {
+			this.initializeInvalidating();
+		}),
 
 		computeProperties: function (props) {
 			if ("dir" in props) {
@@ -85,6 +92,19 @@ define([
 					this.effectiveDir = this.getInheritedDir();
 				}
 			}
+		},
+
+		shouldInitializeRendering: function (oldVals) {
+			// render the template on widget creation and also whenever app changes template prop
+			return !this.rendered || "template" in oldVals;
+		},
+
+		initializeRendering: function () {
+			this.rendered = false;
+			this.preRender();
+			this.render();
+			this.postRender();
+			this.rendered = true;
 		},
 
 		/**
@@ -97,8 +117,10 @@ define([
 		},
 
 		// Override Invalidating#refreshRendering() to execute the template's refreshRendering() code, etc.
-		refreshRendering: function (oldVals) {
-			if (this._templateHandle) {
+		refreshRendering: function (oldVals, justRendered) {
+			if (this._templateHandle && !justRendered) {
+				// Refresh the template based on changed values, but not right after the template is rendered,
+				// because that would be redundant.
 				this._templateHandle.refresh(oldVals);
 			}
 
@@ -128,7 +150,6 @@ define([
 		 * @protected
 		 */
 		preRender: function () {
-			this.widgetId = ++cnt;
 		},
 
 		/**
@@ -146,8 +167,18 @@ define([
 		 * @protected
 		 */
 		render: function () {
+			// Tear down old rendering (if there is one).
+			if (this._templateHandle) {
+				this._templateHandle.destroy();
+				delete this._templateHandle;
+			}
+
+			// Render the widget.
 			if (this.template) {
 				this._templateHandle = this.template(this.ownerDocument, register);
+				if (this.attached && !has("document-register-element")) {
+					this._templateHandle.attach();
+				}
 			}
 		},
 
@@ -199,11 +230,6 @@ define([
 		 * @protected
 		 */
 		postRender: function () {
-			this.initializeInvalidating();
-			if (this._templateHandle) {
-				this.notifyCurrentValue.apply(this, this._templateHandle.dependencies);
-			}
-			this.notifyCurrentValue("dir", "baseClass");	// "dir" triggers computation of effectiveDir
 		},
 
 		//////////// DESTROY FUNCTIONS ////////////////////////////////

--- a/tests/functional/TabIndex.html
+++ b/tests/functional/TabIndex.html
@@ -25,15 +25,16 @@
 				tabIndex: 0
 			});
 			register("test-tab-index", [HTMLElement, TabbableWidget], {
+				label: "",
+
 				render: function () {
 					this.labelNode = document.createElement("span");
-					this.labelNode.tabIndex = 0;
 					this.appendChild(this.labelNode);
 				},
 
 				// dcl.after() to avoid spurious failure on chrome, TODO: investigate more later
 				attachedCallback: register.after(function () {
-					// We could do this in _setTabIndexAttr() but I want to test that observe() is working
+					// Test that observe() is working.
 					this.observe(function (props) {
 						if ("tabIndex" in props) {
 							this.label = this.label + ", updated to " + this._get("tabIndex");
@@ -41,27 +42,23 @@
 					});
 				}),
 
-				_setTabIndexAttr: function (val) {
-					this.labelNode.tabIndex = val;
-					this._set("tabIndex", val);
-				},
-
-				label: "",
-				_setLabelAttr: function (val) {
-					this.labelNode.innerHTML = val;	// should be innerText/textContent but we're just testing
-					this._set("label", val);
+				refreshRendering: function (props) {
+					if ("tabIndex" in props) {
+						this.labelNode.tabIndex = this._get("tabIndex");
+					}
+					if ("label" in props) {
+						this.labelNode.textContent = this.label;
+					}
 				}
 			});
-
-			register.deliver();
 
 			// Set global variable to signal that the test page is ready
 			ready = true;
 		});
 
 		function changeIndices() {
-			document.getElementById("s2").tabIndex = 5;
-			document.getElementById("s3").tabIndex = 6;
+			s2.tabIndex = 5;
+			s3.tabIndex = 6;
 		}
 	</script>
 </head>
@@ -76,12 +73,11 @@
 
 	<fieldset>
 		<legend>Specified tab index</legend>
-		<div id="s1" tabindex="1">div, tabindex=1</div>
-		<test-tab-index id="s3" label="widget, tabindex=2" tabindex="2"></test-tab-index>
-		<test-tab-index id="s2" label="widget, tabindex=1" tabindex="1"></test-tab-index>
-		<div id="s4" tabindex="3">div, tabindex=3</div>
+		<div id="s1" tabindex="1">s1 div, tabindex=1</div>
+		<test-tab-index id="s3" label="s3 widget, tabindex=2" tabindex="2"></test-tab-index>
+		<test-tab-index id="s2" label="s2 widget, tabindex=1" tabindex="1"></test-tab-index>
+		<div id="s4" tabindex="3">s4 div, tabindex=3</div>
 		<button id="button" tabindex="3" onclick="changeIndices();">change indices</button>
-
 	</fieldset>
 </body>
 </html>

--- a/tests/functional/TabIndex.js
+++ b/tests/functional/TabIndex.js
@@ -82,7 +82,7 @@ define([
 				})
 				.execute("return document.activeElement.innerHTML").then(function (value) {
 					// making sure that observe() worked
-					assert.strictEqual(value, "widget, tabindex=1, updated to 5");
+					assert.strictEqual(value, "s2 widget, tabindex=1, updated to 5");
 				})
 				.pressKeys(keys.TAB)
 				.execute("return document.activeElement.parentNode.id").then(function (value) {

--- a/tests/functional/popup.html
+++ b/tests/functional/popup.html
@@ -221,11 +221,6 @@ require([
 	var DialogWithPopupWidget = register("dialog-with-popup-widget", [HTMLElement, DialogWithPopupWidgetMixin], {
 		label: "show popup",
 
-		popup: null,
-		_setPopupAttr: function (popup) {
-			this.button.popup = popup;
-		},
-
 		render: function () {
 			this.innerHTML +=
 				"<div>" + this.title + "</div>" +
@@ -239,6 +234,7 @@ require([
 			this.button = new SimpleDropDownButton({
 				id: this.id + "PopupButton",
 				label: this.label,
+				popup: this.popup,
 				orient: ["after"]	// so popup doesn't cover OK button
 			});
 			this.button.placeAt(this);

--- a/tests/unit/Widget.js
+++ b/tests/unit/Widget.js
@@ -64,7 +64,7 @@ define([
 						// saving the new value without applying it to any this.focusNode Element.
 						this._set("tabIndex", val);
 					},
-					postRender: function () {
+					createdCallback: function () {
 						this.observe(function (props) {
 							if ("tabIndex" in props) {
 								this.watchedTabIndex = this._get("tabIndex");


### PR DESCRIPTION
Allow the widget template to be set or changed dynamically, typically in `computeProperties()`.
`preRender()`, `render()`, and `postRender()` now run *after* widget properties have
been processed and after the first call to `computeProperties()`.

Detailed changes include:

* The widget DOM is *not* rendered in `createdCallback()` anymore.
* By the time `preRender()`, `render()`, and `postRender()` are called, all the user-specified properties are already available.
* Correspondingly, when the template renders, it inserts all the values the user has specified, rather than just leaving them blank and waiting for `refreshRendering()` to do it.  Reverts changes in 17dab339172efc541b2cd5c5225e919e8f4d0261, refs ibm-js/deliteful#249.
* Also, handlebars returns a `destroy()` method to tear down the template.  And it no longer returns the list of dependencies.
* `refreshRendering(oldVals, justRendered)` now gets a flag to tell it if the render() has just been called.  

Widget code should be updated so that:

* Code that should only run once should be moved from `preRender()` and/or `postRender()` to `createdCallback()`.
* Code in `createdCallback()` ~~, `attachedCallback()`,~~ and custom setters that tries to access the widget DOM should be moved to `postRender()` or `refreshRendering()`.
* Code to set the template dynamically (based on user specified properties) should go in `computeProperties()`.   The code should simply set the `this.template` property.
* Stop calling `notifyCurrentValue()` in `postRender()` or `createdCallback()`.  Thanks to ibm-js/decor#56, `computeProperties(this)` and `refreshRendering(this)` are called automatically on widget creation.  Use the `justRendered` flag to `refreshRendering()` to avoid running code on widget creation.

Requires ibm-js/decor#56.

Fixes #414.
