### PR TITLE
Changes to do more preprocessing of templates during build stage

### DIFF
--- a/handlebars.js
+++ b/handlebars.js
@@ -37,7 +37,7 @@ define([
 	"requirejs-dplugins/Promise!",
 	"requirejs-text/text",
 	"./Template"
-], function (module, require, has, Promise, textPlugin, Template) {
+], function (module, moduleRequire, has, Promise, textPlugin, Template) {
 
 	/**
 	 * Given a string like "hello {{foo}} world", generate JS code to output that string,
@@ -324,8 +324,9 @@ define([
 	};
 
 	if (has("builder")) {
-		var fs = require("fs");
-		var jsdom = require("jsdom").jsdom;
+		var fs = require.nodeRequire("fs"),
+			jsdom = require.nodeRequire(require.getNodePath(require.toUrl(module.id).replace(/[^\/]*$/,
+				"node_modules/jsdom"))).jsdom;
 
 		// Info about the MID being currently processed
 		var templateText, templateRequires;

--- a/package.json
+++ b/package.json
@@ -1,11 +1,9 @@
 {
 	"name": "delite",
 	"version": "0.8.0-beta.2",
-	"dependencies": {
-		"jsdom": "7.x"
-	},
 	"devDependencies": {
 		"intern": "3.0.x",
+		"jsdom": "7.x",
 		"leadfoot": "1.x",
 		"grunt": "~0.4.2",
 		"grunt-contrib-jshint": "~0.6.3",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,9 @@
 {
 	"name": "delite",
 	"version": "0.8.0-beta.2",
-	"dependencies": {},
+	"dependencies": {
+		"jsdom": "7.x"
+	},
 	"devDependencies": {
 		"intern": "3.0.x",
 		"leadfoot": "1.x",

--- a/register.js
+++ b/register.js
@@ -8,7 +8,7 @@ define([
 ], function (advise, dcl, schedule, domReady, has) {
 	"use strict";
 
-	var doc = typeof document !== "undefined" && document;	// "typeof document" check so module loads in NodeJS
+	var doc = has("builder") ? require("jsdom").jsdom("") : document;
 
 	// Set to true after the page finishes loading and the parser runs.  Any widgets declared after initialParseComplete
 	// instantiated in a separate code path.
@@ -56,7 +56,7 @@ define([
 	 * @returns {Element} The DOMNode
 	 */
 	function createElement(tag) {
-		if (/-/.test(tag) && !(tag in registry)) {
+		if (/-/.test(tag) && !(tag in registry) && !has("builder")) {
 			// Try to help people that have templates with custom elements but they forgot to do requires="..."
 			console.warn("register.createElement(): undefined tag '" + tag +
 				"', did you forget requires='...' in your template?");

--- a/register.js
+++ b/register.js
@@ -1,14 +1,16 @@
 /** @module delite/register */
 define([
+	"module",
 	"dcl/advise",
 	"dcl/dcl",
 	"decor/schedule",
 	"requirejs-domready/domReady",	// loading as a function, not as a plugin
 	"./features"
-], function (advise, dcl, schedule, domReady, has) {
+], function (module, advise, dcl, schedule, domReady, has) {
 	"use strict";
 
-	var doc = has("builder") ? require("jsdom").jsdom("") : document;
+	var doc = has("builder") ? require.nodeRequire(require.getNodePath(require.toUrl(module.id).replace(/[^\/]*$/,
+		"node_modules/jsdom"))).jsdom("") : document;
 
 	// Set to true after the page finishes loading and the parser runs.  Any widgets declared after initialParseComplete
 	// instantiated in a separate code path.


### PR DESCRIPTION
Refactor how handlebars plugin works in builds.   There are a couple of enhancements/bug fixes from this refactor:

1. Reduce CPU used at page load time by precompiling templates at build time.
2. Makes sure that dependencies specified in templates via the `requires="..."` attribute are properly included into the build.
3. Builds with templates no longer download `requirejs-text/text.js`, `delite/Template.js`, and `delite/handlebars.js` to the browser.  That's assuming that you do a custom build (rather than using the delite/layer.js file), and assuming that the builder and loader are working correctly.  We could also consider excluding `handlebars.js` and `Template.js` from the `delite/layer.js` file.
3. Stop using the `text!` plugin directly since the `parentRequire()` method passed to `load()`
runs in the context of the caller.  If the caller remapped `requirejs-text/text` to point to
another module, it would inadvertently affect the behavior of `delite/handlebars`.

Previously, the build step for `handlebars!foo.html` would merely write this to the layer file:

```js
define("requirejs-text/text!foo.html", function(){
   return "...";
});
```

Thus the build eliminated the XHR to get the template text, but still ran template compilation at page load, and the browser still needed to download`delite/handlebars.js`, and therefore also `requirejs-text/text.js` and `delite/Template.js`.

With this PR, the handlebars build writes the generated template function to the layer, for example:

```js
define('delite/handlebars!deliteful/list/List/_PageLoaderRenderer.html',["deliteful/ProgressIndicator"], function(){
        return function anonymous(document,register
/**/) {
this.setClassComponent('template', (this.loading ? 'd-loading' : ''), this)
var c1 = this.renderNode = register.createElement('div');
...
return {
        ...
        refresh: function(props){
                if('loading' in props)
                        this.setClassComponent('template', (this.loading ? 'd-loading' : ''), this);
                ...
        }.bind(this),

        destroy: function(){
        ...
        }.bind(this)
};
```

Note that this increases the bytes needed for each template.
For example, deliteful's layer.js goes from 112351 bytes / 26393 gzipped
to 127540 bytes / 28103 gzipped.   But on the other hand, it means that Template.js doesn't need to be downloaded to the browser, a savings of 9536 bytes (3230 gzipped).  You don't currently get that savings though if you include delite/layer.js, since delite/layer.js currently includes Template.js and handlebars.js.
    
There's also an intermediate commit where the AST is written to the layer, for example:
    
```js
define('delite/handlebars!foo.html',["delite/Template","deliteful/ProgressIndicator"], function(Template){
    return (new Template({"tag":"template","attributes":{"class":" ...)).func;
});
````
    
The template is half compiled (HTML converted to JSON-esque AST), but it still needs to be converted to a function at run-time, and still requires `delite/Template` to be downloaded to the browser.

cc @clmath 
