### PR TITLE
Fixes #436 - Remove broken link to delite documentation in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,5 +42,4 @@ Then install dependencies with bower (or manually from github if you prefer to):
 
 See the [introductory blog post](http://ibm-js.github.io/2014/07/18/delite-and-deliteful.html) to get started.
 
-Then see the [delite website](http://ibm-js.github.io/delite/) including the
-[documentation section](http://ibm-js.github.io/delite/docs/master/index.html).
+Then see the [delite website](http://ibm-js.github.io/delite/) including the documentation section.


### PR DESCRIPTION
Fixes #436.
I just removed the hyperlink, so a reader is directed to the delite website.

It might be better to link to `http://ibm-js.github.io/delite/docs/0.8.1/index.html`, but that would become outdated whenever there's a new release.