### PR TITLE
Make the procedure of moving all aria-* attributes configurable

### DIFF
--- a/FormWidget.js
+++ b/FormWidget.js
@@ -83,6 +83,14 @@ define([
 		required: false,
 
 		/**
+		 * If set to true, the widget move all aria-* attributes found on the root DOM element of this widget and
+		 * apply those to the focusNode using the overridden setAttribute method.
+		 * @member {boolean}
+		 * @default true
+		 */
+		moveAriaAttributes: true,
+
+		/**
 		 * For widgets with a single tab stop, the Element within the widget, often an `<input>`,
 		 * that gets the focus.  Widgets with multiple tab stops, such as a range slider, should set `tabStops`
 		 * rather than setting `focusNode`.
@@ -289,18 +297,7 @@ define([
 		}),
 
 		postRender: function () {
-			// Move all initially specified aria- attributes to focus node.
-			if (this.focusNode) {
-				var attr, idx = 0;
-				while ((attr = this.attributes[idx++])) {
-					if (/^aria-/.test(attr.name)) {
-						this.setAttribute(attr.name, attr.value);
-
-						// force remove from root node not focus nodes
-						HTMLElement.prototype.removeAttribute.call(this, attr.name);
-					}
-				}
-			}
+			this._moveAriaAttributes();
 		},
 
 		attachedCallback: function () {
@@ -328,7 +325,26 @@ define([
 			if (this.checked !== this.valueNode.checked) {
 				this.checked = this.valueNode.checked;
 			}
-		}
+		},
+
+		/**
+		 * Move all initially specified aria-* attributes to focus node.
+		 *
+		 * @protected
+		 */
+		_moveAriaAttributes: function () {
+			if (this.focusNode && this.moveAriaAttributes) {
+				var attr, idx = 0;
+				while ((attr = this.attributes[idx++])) {
+					if (/^aria-/.test(attr.name)) {
+						this.setAttribute(attr.name, attr.value);
+
+						// force remove from root node not focus nodes
+						HTMLElement.prototype.removeAttribute.call(this, attr.name);
+					}
+				}
+			}
+		},
 	});
 });
 

--- a/FormWidget.js
+++ b/FormWidget.js
@@ -258,7 +258,7 @@ define([
 
 		setAttribute: dcl.superCall(function (sup) {
 			return function (name, value) {
-				if (/^aria-/.test(name) && this.focusNode) {
+				if (/^aria-/.test(name) && this.focusNode && this.moveAriaAttributes) {
 					this.focusNode.setAttribute(name, value);
 				} else {
 					sup.call(this, name, value);
@@ -268,7 +268,7 @@ define([
 
 		getAttribute: dcl.superCall(function (sup) {
 			return function (name) {
-				if (/^aria-/.test(name) && this.focusNode) {
+				if (/^aria-/.test(name) && this.focusNode && this.moveAriaAttributes) {
 					return this.focusNode.getAttribute(name);
 				} else {
 					return sup.call(this, name);
@@ -278,7 +278,7 @@ define([
 
 		hasAttribute: dcl.superCall(function (sup) {
 			return function (name) {
-				if (/^aria-/.test(name) && this.focusNode) {
+				if (/^aria-/.test(name) && this.focusNode && this.moveAriaAttributes) {
 					return this.focusNode.hasAttribute(name);
 				} else {
 					return sup.call(this, name);
@@ -288,7 +288,7 @@ define([
 
 		removeAttribute: dcl.superCall(function (sup) {
 			return function (name) {
-				if (/^aria-/.test(name) && this.focusNode) {
+				if (/^aria-/.test(name) && this.focusNode && this.moveAriaAttributes) {
 					this.focusNode.removeAttribute(name);
 				} else {
 					sup.call(this, name);

--- a/HasDropDown.js
+++ b/HasDropDown.js
@@ -225,7 +225,7 @@ define([
 		postRender: function () {
 			this.behaviorNode = this.behaviorNode || this;
 			this.buttonNode = this.buttonNode || this.behaviorNode;
-			this.popupStateNode = this.focusNode || this.buttonNode;
+			this.popupStateNode = this.popupNode || this.focusNode || this.buttonNode;
 
 			this.popupStateNode.setAttribute("aria-haspopup", "true");
 

--- a/HasDropDown.js
+++ b/HasDropDown.js
@@ -77,6 +77,15 @@ define([
 		buttonNode: null,
 
 		/**
+		 * The DOMElement that will contain some aria attributes.
+		 * Useful for widgets like Combobox that needs some special attibutes like aria-haspopup
+		 * to be defined on a specific element.
+		 * @member {Element}
+		 * @protected
+		 */
+		popupStateNode: null,
+
+		/**
 		 * The widget to display as a popup.  Applications/subwidgets should *either*:
 		 *
 		 * 1. define this property
@@ -225,8 +234,8 @@ define([
 		postRender: function () {
 			this.behaviorNode = this.behaviorNode || this;
 			this.buttonNode = this.buttonNode || this.behaviorNode;
-			this.popupStateNode = this.popupNode || this.focusNode || this.buttonNode;
-
+			this.popupStateNode = this.popupStateNode || this.focusNode || this.buttonNode;
+			
 			this.popupStateNode.setAttribute("aria-haspopup", "true");
 
 			this._HasDropDownListeners = [

--- a/tests/unit/FormWidget.js
+++ b/tests/unit/FormWidget.js
@@ -85,7 +85,8 @@ define([
 
 				assert.strictEqual(myWidget.moveAriaAttributes, false, "moveAriaAttributes should be false");
 				assert.strictEqual(myWidget.attributes.length, 2, "aria-label not on the root");
-				assert.strictEqual(myWidget.attributes['aria-label'].nodeValue, 'test', "aria-label should be equals test");
+				assert.strictEqual(myWidget.attributes["aria-label"].nodeValue,
+					"test", "aria-label should be equals test");
 			},
 
 			"#disabled": function () {

--- a/tests/unit/FormWidget.js
+++ b/tests/unit/FormWidget.js
@@ -6,7 +6,7 @@ define([
 	"delite/FormWidget",
 	"delite/Widget"
 ], function (registerSuite, assert, dcl, register, FormWidget, Widget) {
-	var container, FormWidgetTest;
+	var container, FormWidgetTest, FormWidgetTest2;
 
 	registerSuite({
 		name: "FormWidget",
@@ -27,10 +27,21 @@ define([
 						this.appendChild(this.valueNode);
 					}
 				});
+
+				FormWidgetTest2 = register("form-widget-test-two", [HTMLElement, FormWidget], {
+					moveAriaAttributes: false,
+					render: function () {
+						this.focusNode = this.ownerDocument.createElement("input");
+						this.appendChild(this.focusNode);
+						this.valueNode = this.ownerDocument.createElement("input");
+						this.valueNode.type = "hidden";
+						this.appendChild(this.valueNode);
+					}
+				});
 			},
 
 			// Test that aria attributes are moved to the focus node
-			aria: function () {
+			moveAria: function () {
 				// Create a widget declaratively to test initial aria attributes processed
 				container.innerHTML = "<form-widget-test aria-label='test label' foo='bar'></form-widget-test>";
 				register.parse(container);
@@ -62,6 +73,19 @@ define([
 				assert.strictEqual(myWidget.attributes.length, 1, "root has foo but not aria-label");
 				assert.strictEqual(myWidget.focusNode.getAttribute("aria-label"), "label 2",
 					"aria-label added to focusNode");
+			},
+
+			// Test that aria attributes are moved to the focus node
+			dontMoveAria: function () {
+				// Create a widget declaratively to test initial aria attributes processed
+				container.innerHTML = "<form-widget-test-two aria-label='test' foo='bar'></form-widget-test-two>";
+				register.parse(container);
+
+				var myWidget = container.firstChild;
+
+				assert.strictEqual(myWidget.moveAriaAttributes, false, "moveAriaAttributes should be false");
+				assert.strictEqual(myWidget.attributes.length, 2, "aria-label not on the root");
+				assert.strictEqual(myWidget.attributes['aria-label'].nodeValue, 'test', "aria-label should be equals test");
 			},
 
 			"#disabled": function () {


### PR DESCRIPTION
Make the procedure of moving all aria-* attributes from the root element to the focusNode using a property called **moveAriaAttributes**. By default, the property is _true_ so components extending FormWidget will continue to work as normal.